### PR TITLE
test(app): add wait for app to be loaded before testing

### DIFF
--- a/src/__tests__/App.tsx
+++ b/src/__tests__/App.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import App from 'App';
 import renderWithProviders from 'testUtils';
 
@@ -7,8 +7,10 @@ describe('<App />', () => {
     window.history.pushState({}, 'Home', '/');
     renderWithProviders(<App />, false);
 
-    expect(
-      screen.getAllByText('Get started filing your mortgage or small business lending data')[0]
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getAllByText('Get started filing your mortgage or small business lending data')[0]
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Changes

- Adds a waitFor to the app.tsx test to fix a problem where the test was looking for text in the document before it was loaded.

## How to test this PR

1. Run yarn test locally or check out the GitHub actions results below.

## Screenshots

Before:
![Screenshot 2023-09-14 at 12 58 10 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/bb6ec33f-9364-4bd6-aa07-9e8b43a25163)

After:
![Screenshot 2023-09-14 at 1 02 35 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/f701ad47-1149-461f-9a4d-e3a00196a107)

## Notes:
While reviewing a PR, I noticed that the github action tests have been failing for awhile, so hopefully this fixes things. 🤞
