### PR TITLE
fix(build): always build docker images to avoid cache issues

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -55,7 +55,7 @@ print_success "All directories exist."
 
 cd sbl-project
 docker pull
-docker compose up -d
+docker compose up -d --build
 
 # Check the exit code of the previous command
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Changes

- always build docker images to avoid docker cache issues

## How to test this PR

1. Do the docker images build when you run `start.sh`?

## Screenshots
![Screenshot 2023-12-21 at 3 55 53 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/ab14137a-7afe-4bae-9378-d1f822efc5af)
