### PR TITLE
[Institutional Details] Add lei status, lei type name, primary federal regulator name, misc small edits

### DIFF
--- a/src/pages/Filing/InstitutionDetails/FinancialInstitutionDetails.tsx
+++ b/src/pages/Filing/InstitutionDetails/FinancialInstitutionDetails.tsx
@@ -12,7 +12,7 @@ export function FinancialInstitutionDetails({
 }): JSX.Element {
   const street2 = data.hq_address_street_2 ?? '';
   const domains = data.domains ?? [];
-  const domainString = domains.map((domain: Domain) => domain.domain).join(',');
+  const domainString = domains.map((domain: Domain) => domain.domain).join(', ');
 
   return (
     <>
@@ -45,6 +45,7 @@ export function FinancialInstitutionDetails({
           }
         />
         <DisplayField label='LEI' value={data.lei} />
+        <DisplayField className="capitalize" label='LEI status' value={data.is_active?.toString()} />
         <DisplayField label='Email domain' value={domainString} />
       </WellContainer>
     </>

--- a/src/pages/Filing/InstitutionDetails/IdentifyingInformation.tsx
+++ b/src/pages/Filing/InstitutionDetails/IdentifyingInformation.tsx
@@ -30,11 +30,13 @@ export function IdentifyingInformation({
         />
         <DisplayField
           label='Federal prudential regulator'
-          value={data.primary_federal_regulator_id}
+          value={`${data.primary_federal_regulator.name} (${data.primary_federal_regulator.id})`}
         />
         <DisplayField
           label='Type of financial institution'
-          value={data.sbl_institution_type_id}
+          // TODO: Ask Le about why this type name ends with a period, see:
+          // https://github.com/cfpb/sbl-frontend/issues/137
+          value={(data.sbl_institution_type.name).replace(/\.$/, "")}
         />
       </WellContainer>
     </>

--- a/src/pages/ProfileForm/types.ts
+++ b/src/pages/ProfileForm/types.ts
@@ -32,15 +32,32 @@ export const domainSchema = z.object({
 
 export const institutionDetailsApiTypeSchema = z.object({
   lei: z.string().optional(),
+  is_active: z.boolean().optional(),
   name: z.string().optional(),
   tax_id: z.string().optional(),
   rssd_id: z.number().optional(),
-  primary_federal_regulator_id: z.string().optional(),
-  hmda_institution_type_id: z.string().optional(),
-  sbl_institution_type_id: z.string().optional(),
+  primary_federal_regulator: z.object({
+    id: z.string(),
+    name: z.string(),
+  }).optional(),
+  hmda_institution_type_id: z.object({
+    id: z.string(),
+    name: z.string(),
+  }).optional(),
+  sbl_institution_type: z.object({
+    id: z.string(),
+    name: z.string(),
+  }).optional(),
   hq_address_street_1: z.string().optional(),
   hq_address_street_2: z.string().optional(),
   hq_address_city: z.string().optional(),
+  // Do we still need hq_address_state_code in addition to this hq_address_state object? See:
+  // TODO: Ask Le about why this type name ends with a period, see:
+  // https://github.com/cfpb/sbl-frontend/issues/137
+  hq_address_state: z.object({
+    code: z.string(),
+    name: z.string(),
+  }).optional(),
   hq_address_state_code: z.string().optional(),
   hq_address_zip: z.string().optional(),
   parent_lei: z.string().optional(),


### PR DESCRIPTION
Porting some of the work from the demo. This PR cleans up the institutional details page a bit by adding LEI status, LEI type name, primary federal regulator name, and some minor fixes.

Closes: #130 

## Changes
- add LEI status
- add LEI type name
- add primary federal regulator name
- space after comma in email domains
- remove trailing periods in sbl institution type
- adds new property types

## How to test this PR

1. Do these changes appear on the institution details page and bring us closer to MVP?

## Screenshots
![localhost_8899_institution_TESTBANK123 (3)](https://github.com/cfpb/sbl-frontend/assets/19983248/1a2b557b-cd07-468a-a37e-c9d7195dfc04)
