### PR TITLE
fix(notices): add missed git stash that fixes page padding

### DIFF
--- a/src/pages/Filing/Notices.less
+++ b/src/pages/Filing/Notices.less
@@ -5,6 +5,6 @@
 // override content_main padding for y axis for special paperwork/privacy pages
 @layer components {
   .notices .content_main {
-    padding-top: 1.875rem;
+    padding-top: 0;
   }
 }

--- a/src/pages/Filing/PaperworkNotice.tsx
+++ b/src/pages/Filing/PaperworkNotice.tsx
@@ -9,7 +9,7 @@ function PaperworkNotice(): ReactElement {
     <Layout.Main layout='2-1' bleedbar classes='notices'>
       <Layout.Wrapper>
         <Layout.Content flushBottom>
-          <CrumbTrail className='mt-[10rem]'>
+          <CrumbTrail>
             <RouterLink to='/'>Platform home</RouterLink>
           </CrumbTrail>
           <TextIntroduction


### PR DESCRIPTION
Forgot to add this little change from my git stash when merging things in.

## Changes

- fixes padding on notice pages to align with BreadCrumb changes
- removes a tailwind class I was using to test out BreadCrumb styles

## How to test this PR

1. Are there 30 pixels between the breadcrumb and the top of the main content for the PRA and Privacy Act pages?

## Screenshots
#### _Before_
![Screenshot 2024-01-11 at 7 18 36 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/089fc7ca-49cc-41e6-8d63-3be68a5d8f77)
![Screenshot 2024-01-11 at 7 18 02 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/843b0729-a5c1-44f0-8c3b-0710f3a287c0)


### _After_
![Screenshot 2024-01-11 at 7 16 49 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/79101849-5b0c-49c2-9b27-bfb35bbeb936)

![Screenshot 2024-01-11 at 7 17 06 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/d9f1f825-215f-4c03-9ded-5096ccb008a4)
