### PR TITLE
design(home): last minute unauthenticated landing copy edits

### DIFF
--- a/src/pages/Filing/FilingHome.tsx
+++ b/src/pages/Filing/FilingHome.tsx
@@ -153,7 +153,7 @@ function Home(): ReactElement {
               </ListItem>
             </AdditionalResources>
             <Divider className='my-[2.813rem]' />
-            <Heading type='5'>Privacy Act Notice</Heading>
+            <Heading type='5'>Privacy Act</Heading>
             <Paragraph>
               The information in this system is being collected to facilitate
               the supervision of companies under CFPB{'\u2019'}s authority.
@@ -161,7 +161,7 @@ function Home(): ReactElement {
             <List className='mt-[1rem] list-none pl-0' isLinks>
               <ListItem>
                 <ListLink href='/privacy-act-notice'>
-                  View Privacy Act Notice
+                  View Privacy Act notice
                 </ListLink>
               </ListItem>
             </List>

--- a/src/pages/Filing/PaperworkNotice.tsx
+++ b/src/pages/Filing/PaperworkNotice.tsx
@@ -13,7 +13,7 @@ function PaperworkNotice(): ReactElement {
             <RouterLink to='/'>Platform home</RouterLink>
           </CrumbTrail>
           <TextIntroduction
-            heading='Paperwork Reduction Act'
+            heading='Paperwork Reduction Act statement'
             subheading='According to the Paperwork Reduction Act of 1995, an agency may not conduct or sponsor, and a person is not required to respond to a collection of information unless it displays a valid OMB control number.'
             description={
               <>

--- a/src/pages/Filing/PrivacyNotice.tsx
+++ b/src/pages/Filing/PrivacyNotice.tsx
@@ -19,7 +19,7 @@ function PrivacyNotice(): ReactElement {
             <RouterLink to='/'>Platform home</RouterLink>
           </CrumbTrail>
           <TextIntroduction
-            heading='Privacy Act Notice'
+            heading='Privacy Act notice'
             subheading={`The information in this system is being collected to facilitate the supervision of companies under the CFPB\u2019s authority.`}
             description={
               <>


### PR DESCRIPTION
We got some last minute direction on the PRA and Privacy Act copy that we need to update:
![Screenshot 2024-01-16 at 1 06 55 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/8919b213-f687-4352-b4fb-f6e07af0f147)

## Changes

_Privacy Act_
- Heading: Privacy Act Notice -> Privacy Act
- Link: View Privacy Act Notice -> View Privacy Act notice
- Heading on separate page: Privacy Act Notice -> Privacy Act notice

_PRA_
- Heading on separate page: Paperwork Reduction Act Statement -> Paperwork Reduction Act statement

## How to test this PR

1. Does the copy in the screenshots match the Figma comment direction?

## Screenshots
![Screenshot 2024-01-16 at 1 01 28 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/667a400e-50ad-405c-96fc-1448b3b8e479)

![Screenshot 2024-01-16 at 1 03 15 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/9053f0b9-fb33-4c54-ae77-52f037b626ce)

![Screenshot 2024-01-16 at 1 03 31 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/aaa6c1e5-f8d1-41ec-b6d6-691209618a90)
