### PR TITLE
fix(home): fix <li> with direct descendant <li>

### DIFF
--- a/src/pages/Filing/FilingHome.tsx
+++ b/src/pages/Filing/FilingHome.tsx
@@ -8,7 +8,6 @@ import {
   Layout,
   Link,
   List,
-  ListItem,
   ListLink,
   Paragraph,
   WellContent,
@@ -96,15 +95,16 @@ function Home(): ReactElement {
               heading='Get help'
               text='Our support staff is available to help. Please allow 24-48 hours for response time during normal business hours.'
               links={[
-                <ListLink
+                <Link
                   href='https://www.consumerfinance.gov/compliance/compliance-resources/small-business-lending-resources/small-business-lending-collection-and-reporting-requirements/small-business-lending-rule-faqs/'
                   key='faq'
+                  type='list'
                 >
                   Find answers to frequently asked questions
-                </ListLink>,
-                <ListLink href={sblHelpLink} key='ask-a-question'>
+                </Link>,
+                <Link href={sblHelpLink} key='ask-a-question' type='list'>
                   Contact our support staff
-                </ListLink>,
+                </Link>,
               ]}
             />
             {/* TODO: all these bespoke spacing values should probably be replaced with DSR spacing
@@ -136,21 +136,15 @@ function Home(): ReactElement {
           </Layout.Content>
           <Layout.Sidebar id='sidebar'>
             <AdditionalResources>
-              <ListItem>
-                <ListLink href='https://www.consumerfinance.gov/rules-policy/final-rules/small-business-lending-under-the-equal-credit-opportunity-act-regulation-b/'>
-                  Final Rule
-                </ListLink>
-              </ListItem>
-              <ListItem>
-                <ListLink href='https://www.consumerfinance.gov/data-research/small-business-lending/filing-instructions-guide/2024-guide/'>
-                  Filing instructions guide
-                </ListLink>
-              </ListItem>
-              <ListItem>
-                <ListLink href='https://www.consumerfinance.gov/compliance/compliance-resources/small-business-lending-resources/small-business-lending-collection-and-reporting-requirements/'>
-                  Collection and reporting requirements
-                </ListLink>
-              </ListItem>
+              <ListLink href='https://www.consumerfinance.gov/rules-policy/final-rules/small-business-lending-under-the-equal-credit-opportunity-act-regulation-b/'>
+                Final Rule
+              </ListLink>
+              <ListLink href='https://www.consumerfinance.gov/data-research/small-business-lending/filing-instructions-guide/2024-guide/'>
+                Filing instructions guide
+              </ListLink>
+              <ListLink href='https://www.consumerfinance.gov/compliance/compliance-resources/small-business-lending-resources/small-business-lending-collection-and-reporting-requirements/'>
+                Collection and reporting requirements
+              </ListLink>
             </AdditionalResources>
             <Divider className='my-[2.813rem]' />
             <Heading type='5'>Privacy Act</Heading>
@@ -159,11 +153,9 @@ function Home(): ReactElement {
               the supervision of companies under CFPB{'\u2019'}s authority.
             </Paragraph>
             <List className='mt-[1rem] list-none pl-0' isLinks>
-              <ListItem>
-                <ListLink href='/privacy-act-notice'>
-                  View Privacy Act notice
-                </ListLink>
-              </ListItem>
+              <ListLink href='/privacy-act-notice'>
+                View Privacy Act notice
+              </ListLink>
             </List>
             <Divider className='my-[2.813rem]' />
             <Heading type='5'>Paperwork Reduction Act</Heading>
@@ -174,11 +166,9 @@ function Home(): ReactElement {
               number. The OMB control number for this collection is 3170-0013.
             </Paragraph>
             <List className='mt-[1rem] list-none pb-10 pl-0' isLinks>
-              <ListItem>
-                <ListLink href='/paperwork-reduction-act-notice'>
-                  View Paperwork Reduction Act statement
-                </ListLink>
-              </ListItem>
+              <ListLink href='/paperwork-reduction-act-notice'>
+                View Paperwork Reduction Act statement
+              </ListLink>
             </List>
           </Layout.Sidebar>
         </Layout.Wrapper>


### PR DESCRIPTION
I got a little `<ListLink`> crazy in the unauthenticated landing page design PR (#154) which put some `<li>`s with direct `<li>` children.

## Changes

- removes extraneous `<li>`s

## How to test this PR

1. Does the style not change on the unauthenticated landing page?
2. Does the console no longer yell at you for having `<li>`s as direct descendants of other `<li>`s?

## Screenshots

### _Before_
![Screenshot 2024-01-16 at 5 15 11 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/e98efeea-098c-4275-b4a5-ca0097a0a7fd)

### _After_ (those font problems still in the console are fixed over here #173)
![Screenshot 2024-01-16 at 5 15 34 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/13794fab-fae7-4c49-b869-dd48ceeea1a0)
