### PR TITLE
chore(git): remove @contolini in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @contolini @meissadia @shindigira
+* @billhimmelsbach @meissadia @shindigira


### PR DESCRIPTION
We've open sourced the repos now, so the CODEOWNERS file is actually working and adding reviewers to things. But that does sadly mean we have to say a tearful goodbye to @contolini from the file. 😢

## Changes

- removed @contolini 
- adds @billhimmelsbach 
- adds a little sadness

## How to test this PR

1. Are you named Chris Contolini and will you see less random PRs pop up in your notifications?

## Screenshots

![Screenshot 2024-01-18 at 5 50 08 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/b336c781-6e3c-4289-9000-a034c7871095)

## Notes

- thanks for your work @contolini! 🎉
