### PR TITLE
fix(Unauthenticated): adjust heading spacing, add divider

### DIFF
--- a/src/pages/Filing/FilingHome.tsx
+++ b/src/pages/Filing/FilingHome.tsx
@@ -44,7 +44,10 @@ function Home(): ReactElement {
                 onClick={(): void => void auth.onLogin()}
               />
             </div>
-            <Heading type='3'>Follow these steps to get started</Heading>
+            <Divider className='my-[2.813rem]' />
+            <Heading className='mb-[1.875rem]' type='3'>
+              Follow these steps to get started
+            </Heading>
             <ProcessStep
               number={1}
               heading='Confirm that your financial institution has an LEI'


### PR DESCRIPTION
Adjusts spacing and adds a divider as per [this design feedback](https://github.com/cfpb/sbl-frontend/issues/192).

Closes: https://github.com/cfpb/sbl-frontend/issues/192

## Changes

- Adds a divider with 45px above and below between the button and the numbered icon list
- Increases space between the heading and the list items to 30px

## How to test this PR

1. Does this page more closely resemble [the designs here](https://github.com/cfpb/sbl-frontend/issues/192)?

## Screenshots
![localhost_8899_ (3)](https://github.com/cfpb/sbl-frontend/assets/19983248/48e233b5-29ff-444a-8bb4-46ba18fa6a94)



## Notes

- The original ticket has a possible additional task:
```
(Possibly) Increase the space after the numbered icon list to 45px (between the list and the well)
```
On inspection, it appears that the space between these two elements is already 45px. Happy to change stuff though if we want to! 👍

![Screenshot 2024-01-30 at 12 18 46 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/7d9d687b-fe3d-43bf-b71d-e801d4778fe9)


