### PR TITLE
fix(institution-details): allow institution type array

### DIFF
--- a/src/pages/Filing/InstitutionDetails/IdentifyingInformation.tsx
+++ b/src/pages/Filing/InstitutionDetails/IdentifyingInformation.tsx
@@ -8,9 +8,14 @@ export function IdentifyingInformation({
 }: {
   data: InstitutionDetailsApiType;
 }): JSX.Element {
-  // TODO: Ask Le about why this type name ends with a period, see:
+  // TODO: Asking Le about 'Other' institution type/detail in mock data and the ending period
   // https://github.com/cfpb/sbl-frontend/issues/137
-  const institutionType = data.sbl_institution_type?.name.replace(/\.$/, '');
+  const institutionTypeNamesArray = data.sbl_institution_types?.map(
+    institutionType => {
+      return institutionType.name.replace(/\.$/, '');
+    },
+  );
+  const institutionTypeNamesString = institutionTypeNamesArray?.join(', ');
 
   return (
     <>
@@ -39,7 +44,7 @@ export function IdentifyingInformation({
         />
         <DisplayField
           label='Type of financial institution'
-          value={institutionType}
+          value={institutionTypeNamesString}
         />
       </WellContainer>
     </>

--- a/src/pages/Filing/InstitutionDetails/IdentifyingInformation.tsx
+++ b/src/pages/Filing/InstitutionDetails/IdentifyingInformation.tsx
@@ -12,7 +12,10 @@ export function IdentifyingInformation({
   // https://github.com/cfpb/sbl-frontend/issues/137
   const institutionTypeNamesArray = data.sbl_institution_types?.map(
     institutionType => {
-      return institutionType.name.replace(/\.$/, '');
+      if (institutionType.sbl_type.name == 'Other') {
+        return institutionType.details;
+      }
+      return institutionType.sbl_type.name.replace(/\.$/, '');
     },
   );
   const institutionTypeNamesString = institutionTypeNamesArray?.join(', ');

--- a/src/pages/ProfileForm/types.ts
+++ b/src/pages/ProfileForm/types.ts
@@ -46,11 +46,12 @@ export const institutionDetailsApiTypeSchema = z.object({
       name: z.string(),
     })
     .optional(),
-  sbl_institution_type: z
+  sbl_institution_types: z
     .object({
       id: z.string(),
       name: z.string(),
     })
+    .array()
     .optional(),
   hq_address_street_1: z.string().optional(),
   hq_address_street_2: z.string().optional(),


### PR DESCRIPTION
support change from `sbl_institution_type` to `sbl_institution_types` as an array of user chosen institution types

closes: #180 

## Changes

- create a string from `sbl_institution_types` names

## How to test this PR

1. Does the "Type of financial institution" now render on the "View your financial institution profile" page instead of just rendering "Not available"?

## Screenshots
**Before**
![Screenshot 2024-01-30 at 6 20 26 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/1243411f-28cc-4ff8-830f-c6ecb19236f1)

**After**
![Screenshot 2024-01-30 at 6 20 46 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/13e52cc6-f576-4d1f-a196-05aacca9966a)


## Notes

- I think the seed data is out of date when it comes to institutions with type "Other". I pinged Le over [on this issue](https://github.com/cfpb/sbl-frontend/issues/137#issuecomment-1918230517) about it.
