### PR TITLE
fix(fetchIsDomainAllowed) fix endpoint url

### DIFF
--- a/src/api/requests/fetchIsDomainAllowed.ts
+++ b/src/api/requests/fetchIsDomainAllowed.ts
@@ -6,7 +6,7 @@ const fetchIsDomainAllowed = async (
   domain?: string,
 ): Promise<boolean> => {
   return request<boolean>({
-    url: `/v1/institutions${domain ? `?domain=${domain}` : ''}`,
+    url: `/v1/institutions/domains/allowed?domain=${domain}`,
     method: 'get',
     headers: { Authorization: `Bearer ${auth.user?.access_token}` },
   });


### PR DESCRIPTION
It looks like there was an issue in the endpoint url `fetchIsDomainAllowed` during the axios transition, so this fixes that endpoint.

## Changes

- Change url for `fetchIsDomainAllowed` back to : `/v1/institutions/domains/allowed?domain=${domain}`,

## How to test this PR

1. Can users now be denied based on the their email domain?

## Screenshots
![Screenshot 2024-02-05 at 5 24 53 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/fa5832b3-5e0e-4120-92e2-60372e5127cc)

## Notes

- Maybe take a quick peek at the [other axios changes](https://github.com/cfpb/sbl-frontend/pull/207/files) just to make sure?
- Looking forward to building out some cypress tests to catch these regressions 👍
