### PR TITLE
fix(profile-form): never let a denied domain hit sbl help

### DIFF
--- a/src/pages/ProfileForm/index.tsx
+++ b/src/pages/ProfileForm/index.tsx
@@ -107,7 +107,11 @@ function StepForm(): JSX.Element | null {
   const isUserEmailDomainAssociatedWithAnyInstitution =
     institutionsAssociatedWithUserEmailDomain?.length &&
     institutionsAssociatedWithUserEmailDomain.length > 0;
-  if (isRoutingEnabled && !isUserEmailDomainAssociatedWithAnyInstitution) {
+  if (
+    isRoutingEnabled &&
+    isEmailDomainAllowed &&
+    !isUserEmailDomainAssociatedWithAnyInstitution
+  ) {
     window.location.replace(sblHelpLink);
     return null;
   }


### PR DESCRIPTION
**Now being merged to `main`, same as https://github.com/cfpb/sbl-frontend/pull/232**

After the latest merges, I can still sometimes get users with denied email domains hitting SBL Help even [after fixing the endpoint](https://github.com/cfpb/sbl-frontend/pull/231). This little logic check should make sure that never happens. Should be better too for future devs who want to move around these logic blocks in the future.

## Changes

- add a check to make absolutely sure that users with blocked emails are not redirected to SBL Help

## How to test this PR

1. If a user has a denied domain, then they cannot be directed to SBL Help

## Screenshots
![Screenshot 2024-02-06 at 11 40 35 AM](https://github.com/cfpb/sbl-frontend/assets/19983248/2cc831c9-34fd-4711-82fb-e392e02202ad)


## Notes

- gonna prioritize getting those cypress tests in to check these use cases
