### PR TITLE
documentation(sbl-filing-api): updated list of repos needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,16 @@ A small app to explore Typescript, Vite and React.
 1. Install Node v16.9+: `nvm install && nvm use`
 1. Enable [corepack](https://yarnpkg.com/getting-started/install): `corepack enable`.
 1. [Docker](https://docs.docker.com/get-docker/) engine version 1.13.0+ with docker compose version 3.0+ support needs to be installed to run all the containerized support services.
-1. Have the three repos [sbl-frontend](https://github.com/cfpb/sbl-frontend), [sbl-project](https://github.com/cfpb/sbl-project), and [regtech-user-fi-management](https://github.com/cfpb/regtech-user-fi-management) as **sibling directories**.
+1. Have the four repos [sbl-frontend](https://github.com/cfpb/sbl-frontend), [sbl-project](https://github.com/cfpb/sbl-project), [regtech-user-fi-management](https://github.com/cfpb/regtech-user-fi-management) and [sbl-filing-api](https://github.com/cfpb/sbl-filing-api/) as **sibling directories**.
    ```
    code-root
    ├── regtech-user-fi-management
+   ├── sbl-filing-api
    ├── sbl-project
    └── sbl-frontend (current repository)
+   
    ```
-1. Make sure to `git pull` in each of the three directories to have the latest commits.
+1. Make sure to `git pull` in each of the four directories to have the latest commits.
 1. Create a `.env` based on the [ENV-GUIDE.md](./ENV-GUIDE.md).
 1. In the `sbl-frontend` command line, run `yarn start`. This script uses `docker-compose` to start up Docker containers of all of the project components (User management, API, Frontend) to get you up and running.
 


### PR DESCRIPTION
https://github.com/cfpb/sbl-filing-api is now a required repo in order to use `yarn start`