### PR TITLE
feat(start.sh): add new repos, add update command, fail on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A small app to explore Typescript, Vite and React.
 
    ```
 
-1. Make sure to `git pull` in each of the four directories to have the latest commits.
+1. Make sure to `git pull` in each of the five directories to have the latest commits.
 1. Create a `.env` based on the [ENV-GUIDE.md](./ENV-GUIDE.md).
 1. In the `sbl-frontend` command line, run `yarn start`. This script uses `docker-compose` to start up Docker containers of all of the project components (User management, API, Frontend) to get you up and running.
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,18 @@ A small app to explore Typescript, Vite and React.
 1. Install Node v16.9+: `nvm install && nvm use`
 1. Enable [corepack](https://yarnpkg.com/getting-started/install): `corepack enable`.
 1. [Docker](https://docs.docker.com/get-docker/) engine version 1.13.0+ with docker compose version 3.0+ support needs to be installed to run all the containerized support services.
-1. Have the four repos [sbl-frontend](https://github.com/cfpb/sbl-frontend), [sbl-project](https://github.com/cfpb/sbl-project), [regtech-user-fi-management](https://github.com/cfpb/regtech-user-fi-management) and [sbl-filing-api](https://github.com/cfpb/sbl-filing-api/) as **sibling directories**.
+1. Have the five repos [sbl-frontend](https://github.com/cfpb/sbl-frontend), [sbl-project](https://github.com/cfpb/sbl-project), [regtech-user-fi-management](https://github.com/cfpb/regtech-user-fi-management), [sbl-filing-api](https://github.com/cfpb/sbl-filing-api/), and [regtech-mail-api](https://github.com/cfpb/regtech-mail-api) as **sibling directories**.
+
    ```
    code-root
+   ├── regtech-mail-api
    ├── regtech-user-fi-management
    ├── sbl-filing-api
    ├── sbl-project
    └── sbl-frontend (current repository)
-   
+
    ```
+
 1. Make sure to `git pull` in each of the four directories to have the latest commits.
 1. Create a `.env` based on the [ENV-GUIDE.md](./ENV-GUIDE.md).
 1. In the `sbl-frontend` command line, run `yarn start`. This script uses `docker-compose` to start up Docker containers of all of the project components (User management, API, Frontend) to get you up and running.
@@ -45,6 +48,7 @@ If you'll be using VS Code, be sure to:
 - `yarn build` - build for production. The generated files will be on the `dist` folder.
 - `yarn preview` - locally preview the production build.
 - `yarn start` - start the app's full stack (auth, api, frontend) via `docker-compose`
+- `yarn update` - update all dependent repos and then start the app's full stack (auth, api, frontend) via `docker-compose`
 - `yarn test` - run unit and integration tests related to changed files based on git.
 - `yarn test:ci` - run all unit and integration tests in CI mode.
 - `yarn test:e2e` - run all e2e tests with the Cypress Test Runner.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "docker-build": "docker build -t test_sbl .",
     "docker-run": "docker run -d -p 8080:8080 test_sbl && open http://localhost:8080",
     "start": "sh start.sh",
+    "update": "sh start.sh -u",
     "postinstall": "husky install",
     "preview": "yarn build && vite preview",
     "preview:test": "start-server-and-test preview http://localhost:4173",


### PR DESCRIPTION
Updates the start script with the new repos and also provides an easier way to update all the dependent repos.

Closes: #264

## Changes
- add new repos: [regtech-mail-api](https://github.com/cfpb/regtech-mail-api) and [sbl-filing-api](https://github.com/cfpb/sbl-filing-api)
- add `yarn update` (happy to change the name) to checkout all the dependent repos into `main` and pull the latest changes
- adds `set -e` to catch errors if a command exits with a non-zero status that doesn't have explicit error handling
- remove `docker pull` line that has been erroring out silently for awhile

## How to test this PR

1. Does `yarn start` work normally?
2. Does `yarn update` checkout each repo to `main`, pull the latest, and then start up the containers normally?

## Screenshots
_Example `yarn update` run_
![Screenshot 2024-02-20 at 10 56 02 AM](https://github.com/cfpb/sbl-frontend/assets/19983248/01c7f294-5bd7-4f50-bee5-a31be1ce18ec)

_Error handling example with `set -e`: if pending changes would get overwritten, the script fails gracefully_
![Screenshot 2024-02-20 at 9 52 22 AM](https://github.com/cfpb/sbl-frontend/assets/19983248/cc3ec0d7-6b4e-44b4-a572-e896200a0d92)
