### PR TITLE
feat(email-to-case): adjust for new header: case-type

### DIFF
--- a/src/api/axiosService.ts
+++ b/src/api/axiosService.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import type { EmailSubject } from './common';
+import type { CaseType } from './common';
 
 const apiClient = axios.create({
   baseURL: '',
@@ -14,7 +14,7 @@ export interface HeaderType {
 }
 
 export interface HeaderTypeEmail {
-  'X-Mail-Subject': EmailSubject;
+  'case-type': CaseType;
 }
 
 export type HeaderTypeCombined = HeaderType & HeaderTypeEmail;

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -7,9 +7,9 @@ export interface ValidationError {
   errors: Record<string, string[]>;
 }
 
-export const emailSubjects = {
-  UpdateFinancialProfile: '[BETA] Update your financial institution profile',
-  CompleteUserProfile: '[BETA] Complete your user profile',
+export const caseTypes = {
+  UpdateFinancialProfile: 'Update your financial institution profile',
+  CompleteUserProfile: 'Complete your user profile',
 } as const;
 
-export type EmailSubject = (typeof emailSubjects)[keyof typeof emailSubjects];
+export type CaseType = (typeof caseTypes)[keyof typeof caseTypes];

--- a/src/api/requests/submitUpdateFinancialProfile.ts
+++ b/src/api/requests/submitUpdateFinancialProfile.ts
@@ -1,6 +1,6 @@
 import { request } from 'api/axiosService';
-import type { EmailSubject } from 'api/common';
-import { emailSubjects } from 'api/common';
+import type { CaseType } from 'api/common';
+import { caseTypes } from 'api/common';
 import type { SblAuthProperties } from 'api/useSblAuth';
 import type { UFPSchema } from 'pages/Filing/UpdateFinancialProfile/types';
 
@@ -36,8 +36,7 @@ const submitUpdateFinancialProfile = async (
     headers: {
       Authorization: `Bearer ${auth.user?.access_token}`,
       'Content-Type': 'application/x-www-form-urlencoded',
-      'X-Mail-Subject':
-        emailSubjects.UpdateFinancialProfile satisfies EmailSubject,
+      'case-type': caseTypes.UpdateFinancialProfile satisfies CaseType,
     },
   });
 };

--- a/src/api/requests/submitUserProfileFi.ts
+++ b/src/api/requests/submitUserProfileFi.ts
@@ -1,7 +1,7 @@
 /* eslint-disable unicorn/filename-case */
 import { request } from 'api/axiosService';
-import type { EmailSubject } from 'api/common';
-import { emailSubjects } from 'api/common';
+import type { CaseType } from 'api/common';
+import { caseTypes } from 'api/common';
 import type { SblAuthProperties } from 'api/useSblAuth';
 import type { ValidationSchemaCPF } from 'pages/ProfileForm/types';
 import { One } from 'utils/constants';
@@ -33,8 +33,7 @@ const submitUserProfileFi = async (
     body: new URLSearchParams(formattedFinancialInstitutionsObject),
     headers: {
       Authorization: `Bearer ${auth.user?.access_token}`,
-      'X-Mail-Subject':
-        emailSubjects.CompleteUserProfile satisfies EmailSubject,
+      'case-type': caseTypes.CompleteUserProfile satisfies CaseType,
       'Content-Type': 'application/x-www-form-urlencoded',
     },
   });


### PR DESCRIPTION
Updates the headers according [to this PR](https://github.com/cfpb/regtech-mail-api/pull/23) and prior discussions yesterday about the email-to-case system.

We're no longer setting the whole subject, just giving the backend what type of case we want to create.

Closes: #280 

## Changes

- email subject -> case type

## How to test this PR

1. You saw it in the demo! 🎉
