### PR TITLE
style: Remove financial institution button - bottom 15px padding

### DIFF
--- a/src/pages/ProfileForm/CreateProfileForm/index.tsx
+++ b/src/pages/ProfileForm/CreateProfileForm/index.tsx
@@ -117,13 +117,11 @@ function CreateProfileForm(): JSX.Element {
           return (
             <div className='flex flex-col' key={`${field.id}`}>
               {index !== 0 && (
-                <LinkButton
-                  className='ml-auto'
-                  icon='minus'
-                  onClick={onRemoveThisInstitution}
-                >
-                  Remove this financial institution
-                </LinkButton>
+                <div className='ml-auto pb-[0.9375rem]'>
+                  <LinkButton icon='minus' onClick={onRemoveThisInstitution}>
+                    Remove this financial institution
+                  </LinkButton>
+                </div>
               )}
               <AddFinancialInstitution
                 index={index}
@@ -148,7 +146,7 @@ function CreateProfileForm(): JSX.Element {
             label='Submit'
             aria-label='Submit User Profile'
             size='default'
-            type='submit'
+            type='button'
           />
           <Button
             label='Clear form'

--- a/src/pages/ProfileForm/Step1Form/Step1Form.tsx
+++ b/src/pages/ProfileForm/Step1Form/Step1Form.tsx
@@ -134,7 +134,7 @@ function Step1Form(): JSX.Element {
   // const navigate = useNavigate();
 
   // 'Clear Form' function
-  function clearForm(): void {
+  function onClearForm(): void {
     setValue('firstName', '');
     setValue('lastName', '');
     setSelectedFI([]);
@@ -204,6 +204,7 @@ function Step1Form(): JSX.Element {
           <FormButtonGroup>
             <Button
               appearance='primary'
+              // eslint-disable-next-line @typescript-eslint/no-misused-promises
               onClick={onSubmitButtonAction}
               label='Submit'
               aria-label='Submit User Profile'
@@ -213,7 +214,7 @@ function Step1Form(): JSX.Element {
 
             <Button
               label='Clear form'
-              onClick={clearForm}
+              onClick={onClearForm}
               appearance='warning'
               asLink
             />


### PR DESCRIPTION
closes #296 

## Change(s)
- style: There is 15px padding below the "Remove this financial institution" button in -- Create Your User Profile (no associated)
- fix: Create Your User Profile (associated)'s button no longer uses the 'submit' type

## How to test
- Inspect the form to verify padding (0.9375rem - 15px) below the "Remove this financial institution" button.

## Screenshot(s)
<img width="561" alt="Screenshot 2024-03-06 at 4 38 42 PM" src="https://github.com/cfpb/sbl-frontend/assets/13324863/8b422336-1b48-4d86-9ff2-72df4da8dacd">

