### PR TITLE
chore(env): consolidate filing api env vars

### DIFF
--- a/ENV-GUIDE.md
+++ b/ENV-GUIDE.md
@@ -10,7 +10,7 @@ SBL_OIDC_AUTHORITY="http://localhost:8880/realms/regtech"
 SBL_OIDC_CLIENT_ID="regtech-client"
 SBL_OIDC_REDIRECT_URI="http://localhost:${SBL_DEV_PORT}/filing"
 SBL_REGTECH_BASE_URL="http://localhost:8881"
-SBL_REGTECH_FILING_URL="http://localhost:8882"
+SBL_FILING_BASE_URL="http://localhost:8882"
 SBL_MAIL_BASE_URL="http://localhost:8765"
 ```
 

--- a/src/api/common.ts
+++ b/src/api/common.ts
@@ -3,7 +3,7 @@ export const BASE_URL = `${
 }`;
 
 export const FILING_URL = `${
-  import.meta.env.SBL_REGTECH_FILING_URL || 'http://localhost:8882'
+  import.meta.env.SBL_FILING_BASE_URL || 'http://localhost:8882'
 }`;
 
 export interface ValidationError {


### PR DESCRIPTION
We had two env vars in the codebase for the filing api: 
`SBL_FILING_BASE_URL`
`SBL_REGTECH_FILING_URL`

This consolidates them to one, `SBL_FILING_BASE_URL`, sticking with the `BASE_URL` suffix to fit the pattern of `SBL_REGTECH_BASE_URL` and `SBL_MAIL_BASE_URL`. I think we should proabably have a discussion about the env var names before they're [set in the configmap](https://github.com/cfpb/sbl-frontend/issues/256), but maybe next DSR meeeting?

## Changes

- `SBL_REGTECH_FILING_URL` -> `SBL_FILING_BASE_URL`

## How to test this PR

1. Does everything still run if you have `SBL_FILING_BASE_URL` as an env var? (I think people currently might have both in their env files)
