### PR TITLE
style(App): Fixes having the unnecessary whitespace below the FooterCfGov

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,11 @@ import type { UserProfileObject } from 'api/oidc';
 import { fetchUserProfile } from 'api/requests';
 import useSblAuth from 'api/useSblAuth';
 import classNames from 'classnames';
+import FooterWrapper from 'components/FooterWrapper';
 import { Link } from 'components/Link';
 import { LoadingApp, LoadingContent } from 'components/Loading';
 import ScrollToTop from 'components/ScrollToTop';
-import { FooterCfGov, PageHeader } from 'design-system-react';
+import { PageHeader } from 'design-system-react';
 import 'design-system-react/style.css';
 import Error500 from 'pages/Error/Error500';
 import { NotFound404 } from 'pages/Error/NotFound404';
@@ -100,10 +101,10 @@ function BasicLayout(): ReactElement {
   const headerLinks = [...useHeaderAuthLinks()];
 
   return (
-    <div className='h-dvh'>
+    <div className='flex min-h-screen flex-col'>
       <PageHeader links={headerLinks} />
       <Outlet />
-      <FooterCfGov />
+      <FooterWrapper />
     </div>
   );
 }

--- a/src/components/FooterWrapper.tsx
+++ b/src/components/FooterWrapper.tsx
@@ -1,0 +1,5 @@
+import { FooterCfGov } from 'design-system-react';
+
+export default function FooterWrapper() {
+  return <FooterCfGov className='flex-1' />;
+}

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,6 +1,7 @@
-import { FooterCfGov, Heading, Icon, PageHeader } from 'design-system-react';
+import { Heading, Icon, PageHeader } from 'design-system-react';
 import type { ReactElement } from 'react';
 import { useHeaderAuthLinks } from 'utils/useHeaderAuthLinks';
+import FooterWrapper from './FooterWrapper';
 
 export interface LoadingType {
   // TODO: Do we need this rule? Adding Loading.defaultProps = {...} does not fix the error.
@@ -32,10 +33,10 @@ export function LoadingApp({ message }: LoadingType): ReactElement {
   const headerLinks = [...useHeaderAuthLinks()];
 
   return (
-    <div className='h-dvh'>
+    <div className='flex min-h-screen flex-col'>
       <PageHeader links={headerLinks} />
       <LoadingContent {...{ message }} />
-      <FooterCfGov />
+      <FooterWrapper />
     </div>
   );
 }

--- a/src/pages/AuthenticatedLanding/Landing.stories.tsx
+++ b/src/pages/AuthenticatedLanding/Landing.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { FooterCfGov, PageHeader } from 'design-system-react';
+import FooterWrapper from 'components/FooterWrapper';
+import { PageHeader } from 'design-system-react';
 import Landing from './index';
 
 const meta: Meta<typeof Landing> = {
@@ -16,7 +17,7 @@ export const Default: Story = {
     <>
       <PageHeader />
       <Landing />
-      <FooterCfGov />
+      <FooterWrapper />
     </>
   ),
 };


### PR DESCRIPTION
Relies on https://github.com/cfpb/design-system-react/pull/333 being merged into DSR first and carried over

closes #365

## Changes
- style(App): Fixes having the unnecessary whitespace below the FooterCfGov

## How to test this PR

1. `yarn up -i design-system-react` to get the FooterCfGov update
2. Go to any page where FooterCfGov is used (basically all)
3. Zoom out (CMD + - multiple times)
4. See how the footer's grey part still extends to the bottom

## Screenshots BEFORE the fix
![Screenshot 2024-04-02 at 12 29 43 PM](https://github.com/cfpb/sbl-frontend/assets/13324863/72228a6a-508d-428c-a1ff-a54f1ef81aeb)
![Screenshot 2024-04-02 at 12 31 41 PM](https://github.com/cfpb/sbl-frontend/assets/13324863/56bc509b-b0d4-4fce-a074-c83f6c810122)


## Screenshots WITH fix
<img width="1439" alt="Screenshot 2024-04-02 at 5 00 31 PM" src="https://github.com/cfpb/sbl-frontend/assets/13324863/ad19f079-f265-4c40-900c-98071b0f3a15">

