### PR TITLE
feat: InputEntry - Support optional helper text

### DIFF
--- a/src/components/InputEntry.tsx
+++ b/src/components/InputEntry.tsx
@@ -19,6 +19,7 @@ interface InputEntryProperties
   showError?: boolean;
   children?: ReactNode;
   isOptional?: boolean;
+  helperText?: string | undefined;
 }
 
 const InputEntry = forwardRef<HTMLInputElement, InputEntryProperties>(
@@ -35,6 +36,7 @@ const InputEntry = forwardRef<HTMLInputElement, InputEntryProperties>(
       children,
       isOptional = false,
       type = 'text',
+      helperText,
       ...properties
     },
     reference,
@@ -46,10 +48,18 @@ const InputEntry = forwardRef<HTMLInputElement, InputEntryProperties>(
           {hideInput ? null : (
             <>
               <label htmlFor={id}>
-                <Heading type='3' className='h4 mb-[0.625rem]'>
+                <Heading
+                  type='3'
+                  className={`h4 ${helperText ? 'mb-0' : 'mb-[0.625rem]'}`}
+                >
                   {label}
                   {isOptional ? <LabelOptional /> : null}
                 </Heading>
+                {helperText ? (
+                  <div className='my-[0.625rem] text-labelHelper'>
+                    {helperText}
+                  </div>
+                ) : null}
               </label>
               {children}
               <TextInput

--- a/src/components/InputEntry.tsx
+++ b/src/components/InputEntry.tsx
@@ -19,7 +19,7 @@ interface InputEntryProperties
   showError?: boolean;
   children?: ReactNode;
   isOptional?: boolean;
-  helperText?: string | undefined;
+  helperText?: string;
 }
 
 const InputEntry = forwardRef<HTMLInputElement, InputEntryProperties>(

--- a/src/pages/Filing/UpdateFinancialProfile/UfpForm.tsx
+++ b/src/pages/Filing/UpdateFinancialProfile/UfpForm.tsx
@@ -118,7 +118,7 @@ export default function UFPForm({
         <UpdateIdentifyingInformation
           {...{ data, register, setValue, watch, formErrors }}
         />
-        <UpdateAffiliateInformation {...{ register, formErrors }} />
+        <UpdateAffiliateInformation {...{ register, formErrors, watch }} />
         <AdditionalDetails {...{ register }} />
 
         <FormButtonGroup>

--- a/src/pages/Filing/UpdateFinancialProfile/UpdateAffiliateInformation.tsx
+++ b/src/pages/Filing/UpdateFinancialProfile/UpdateAffiliateInformation.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react';
 import type { FieldErrors, UseFormRegister } from 'react-hook-form';
 import { FormSectionWrapper } from '../../../components/FormSectionWrapper';
 import InputEntry from '../../../components/InputEntry';
-import InstitutionDataLabels from '../formHelpers';
+import InstitutionDataLabels, { InstitutionHelperText } from '../formHelpers';
 import { processRssdId } from './processRssdId';
 import type { UpdateInstitutionType } from './types';
 
@@ -39,20 +39,22 @@ function UpdateAffiliateInformation({
           showError
         />
         <InputEntry
-          label={InstitutionDataLabels.lei}
-          id='parent_lei'
-          {...register('parent_lei')}
-          errorMessage={formErrors.parent_lei?.message}
-          showError
-        />
-        <InputEntry
           label={InstitutionDataLabels.rssd}
+          helperText={InstitutionHelperText.rssd}
           id='parent_rssd_id'
           type='number'
           {...register('parent_rssd_id', {
             setValueAs: processRssdId,
           })}
           errorMessage={formErrors.parent_rssd_id?.message}
+          showError
+        />
+        <InputEntry
+          label={InstitutionDataLabels.lei}
+          helperText={InstitutionHelperText.lei}
+          id='parent_lei'
+          {...register('parent_lei')}
+          errorMessage={formErrors.parent_lei?.message}
           showError
         />
 
@@ -69,20 +71,22 @@ function UpdateAffiliateInformation({
           showError
         />
         <InputEntry
-          label={InstitutionDataLabels.lei}
-          id='top_holder_lei'
-          {...register('top_holder_lei')}
-          errorMessage={formErrors.top_holder_lei?.message}
-          showError
-        />
-        <InputEntry
           label={InstitutionDataLabels.rssd}
+          helperText={InstitutionHelperText.rssd}
           id='top_holder_rssd_id'
           type='number'
           {...register('top_holder_rssd_id', {
             setValueAs: processRssdId,
           })}
           errorMessage={formErrors.top_holder_rssd_id?.message}
+          showError
+        />
+        <InputEntry
+          label={InstitutionDataLabels.lei}
+          helperText={InstitutionHelperText.lei}
+          id='top_holder_lei'
+          {...register('top_holder_lei')}
+          errorMessage={formErrors.top_holder_lei?.message}
           showError
           isLast
         />

--- a/src/pages/Filing/UpdateFinancialProfile/UpdateAffiliateInformation.tsx
+++ b/src/pages/Filing/UpdateFinancialProfile/UpdateAffiliateInformation.tsx
@@ -2,22 +2,35 @@ import Links from 'components/CommonLinks';
 import SectionIntro from 'components/SectionIntro';
 import { Divider, Heading, WellContainer } from 'design-system-react';
 import type { ReactNode } from 'react';
-import type { FieldErrors, UseFormRegister } from 'react-hook-form';
+import type {
+  FieldErrors,
+  UseFormRegister,
+  UseFormWatch,
+} from 'react-hook-form';
 import { FormSectionWrapper } from '../../../components/FormSectionWrapper';
 import InputEntry from '../../../components/InputEntry';
 import InstitutionDataLabels, { InstitutionHelperText } from '../formHelpers';
 import { processRssdId } from './processRssdId';
 import type { UpdateInstitutionType } from './types';
 
+const parentRssd = 'parent_rssd_id';
+const topHolderRssd = 'top_holder_rssd_id';
+
 function UpdateAffiliateInformation({
   heading,
   register,
   formErrors,
+  watch,
 }: {
   heading?: ReactNode;
   register: UseFormRegister<UpdateInstitutionType>;
   formErrors: FieldErrors<UpdateInstitutionType>;
+  watch: UseFormWatch<UpdateInstitutionType>;
 }): JSX.Element {
+  // setValueAs leaves displayed value out of sync with saved value
+  const parentRssdValue = watch(parentRssd);
+  const topHolderRssdValue = watch(topHolderRssd);
+
   return (
     <FormSectionWrapper>
       <SectionIntro heading={heading}>
@@ -41,11 +54,11 @@ function UpdateAffiliateInformation({
         <InputEntry
           label={InstitutionDataLabels.rssd}
           helperText={InstitutionHelperText.rssd}
-          id='parent_rssd_id'
-          type='number'
-          {...register('parent_rssd_id', {
+          id={parentRssd}
+          {...register(parentRssd, {
             setValueAs: processRssdId,
           })}
+          value={parentRssdValue}
           errorMessage={formErrors.parent_rssd_id?.message}
           showError
         />
@@ -73,11 +86,11 @@ function UpdateAffiliateInformation({
         <InputEntry
           label={InstitutionDataLabels.rssd}
           helperText={InstitutionHelperText.rssd}
-          id='top_holder_rssd_id'
-          type='number'
-          {...register('top_holder_rssd_id', {
+          id={topHolderRssd}
+          {...register(topHolderRssd, {
             setValueAs: processRssdId,
           })}
+          value={topHolderRssdValue}
           errorMessage={formErrors.top_holder_rssd_id?.message}
           showError
         />

--- a/src/pages/Filing/UpdateFinancialProfile/UpdateIdentifyingInformation.tsx
+++ b/src/pages/Filing/UpdateFinancialProfile/UpdateIdentifyingInformation.tsx
@@ -76,7 +76,6 @@ function UpdateIdentifyingInformation({
           id={rssdID}
           label={InstitutionDataLabels.rssd}
           helperText={InstitutionHelperText.rssd}
-          type='number'
           {...register(rssdID, {
             setValueAs: processRssdId,
           })}

--- a/src/pages/Filing/UpdateFinancialProfile/UpdateIdentifyingInformation.tsx
+++ b/src/pages/Filing/UpdateFinancialProfile/UpdateIdentifyingInformation.tsx
@@ -12,7 +12,7 @@ import type {
 import type { InstitutionDetailsApiType } from 'types/formTypes';
 import { FormSectionWrapper } from '../../../components/FormSectionWrapper';
 import { DisplayField } from '../ViewInstitutionProfile/DisplayField';
-import InstitutionDataLabels from '../formHelpers';
+import InstitutionDataLabels, { InstitutionHelperText } from '../formHelpers';
 import TypesFinancialInstitutionSection from './TypesFinancialInstitutionSection';
 import { processRssdId } from './processRssdId';
 import type { UpdateInstitutionType } from './types';
@@ -75,6 +75,7 @@ function UpdateIdentifyingInformation({
         <InputEntry
           id={rssdID}
           label={InstitutionDataLabels.rssd}
+          helperText={InstitutionHelperText.rssd}
           type='number'
           {...register(rssdID, {
             setValueAs: processRssdId,
@@ -85,6 +86,7 @@ function UpdateIdentifyingInformation({
         <InputEntry
           id={taxID}
           label={InstitutionDataLabels.tin}
+          helperText={InstitutionHelperText.tin}
           {...register(taxID)}
           errorMessage={formErrors[taxID]?.message}
         />

--- a/src/pages/Filing/formHelpers.ts
+++ b/src/pages/Filing/formHelpers.ts
@@ -14,7 +14,7 @@ const InstitutionDataLabels = {
 export const InstitutionHelperText = {
   rssd: 'RSSD ID must be a number.',
   tin: 'TIN must be 2 digits, followed by a dash, followed by 7 digits.',
-  lei: 'LEI must be 20 characters and contain only A-Z and 0-9 (no special characters)',
+  lei: 'LEI must be 20 characters and contain only A-Z and 0-9 (no special characters).',
 };
 
 export default InstitutionDataLabels;

--- a/src/pages/Filing/formHelpers.ts
+++ b/src/pages/Filing/formHelpers.ts
@@ -11,4 +11,10 @@ const InstitutionDataLabels = {
   tin: 'Federal Taxpayer Identification Number (TIN)',
 };
 
+export const InstitutionHelperText = {
+  rssd: 'RSSD ID must be a number.',
+  tin: 'TIN must be 2 digits, followed by a dash, followed by 7 digits.',
+  lei: 'LEI must be 20 characters and contain only A-Z and 0-9 (no special characters)',
+};
+
 export default InstitutionDataLabels;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,7 @@ const config = {
         stepIndicatorComplete: '#254B87',
         stepIndicatorCurrent: '#0072CE',
         stepIndicatorIncomplete: '#D2D3D5',
+        labelHelper: '#43484E',
       },
       fontFamily: {
         inter: ['Inter', ...defaultConfig.theme.fontFamily.sans],


### PR DESCRIPTION
Closes #377

## Changes
- feat: Add `helperText` to `<InpuEntry>`
- feat: Add `labelHelper` color to Tailwind config
- task: Add helper text to Update Institution profile's RSSD, LEI, and TIN fields
- task: Reorders display of RSSD fields

## Screenshots
![screencapture-localhost-8899-institution-123456789TESTBANK123-update-2024-04-03-14_21_27](https://github.com/cfpb/sbl-frontend/assets/2592907/29a8bb81-38f7-4944-9c5a-dd93f5259969)
