### PR TITLE
fix: Update Institution profile - Make RSSD inputs text (remove arrows)

### DIFF
--- a/src/pages/Filing/UpdateFinancialProfile/UfpForm.tsx
+++ b/src/pages/Filing/UpdateFinancialProfile/UfpForm.tsx
@@ -118,7 +118,7 @@ export default function UFPForm({
         <UpdateIdentifyingInformation
           {...{ data, register, setValue, watch, formErrors }}
         />
-        <UpdateAffiliateInformation {...{ register, formErrors }} />
+        <UpdateAffiliateInformation {...{ register, formErrors, watch }} />
         <AdditionalDetails {...{ register }} />
 
         <FormButtonGroup>

--- a/src/pages/Filing/UpdateFinancialProfile/UpdateAffiliateInformation.tsx
+++ b/src/pages/Filing/UpdateFinancialProfile/UpdateAffiliateInformation.tsx
@@ -2,22 +2,35 @@ import Links from 'components/CommonLinks';
 import SectionIntro from 'components/SectionIntro';
 import { Divider, Heading, WellContainer } from 'design-system-react';
 import type { ReactNode } from 'react';
-import type { FieldErrors, UseFormRegister } from 'react-hook-form';
+import type {
+  FieldErrors,
+  UseFormRegister,
+  UseFormWatch,
+} from 'react-hook-form';
 import { FormSectionWrapper } from '../../../components/FormSectionWrapper';
 import InputEntry from '../../../components/InputEntry';
 import InstitutionDataLabels, { InstitutionHelperText } from '../formHelpers';
 import { processRssdId } from './processRssdId';
 import type { UpdateInstitutionType } from './types';
 
+const parentRssd = 'parent_rssd_id';
+const topHolderRssd = 'top_holder_rssd_id';
+
 function UpdateAffiliateInformation({
   heading,
   register,
   formErrors,
+  watch,
 }: {
   heading?: ReactNode;
   register: UseFormRegister<UpdateInstitutionType>;
   formErrors: FieldErrors<UpdateInstitutionType>;
+  watch: UseFormWatch<UpdateInstitutionType>;
 }): JSX.Element {
+  // setValueAs leaves displayed value out of sync with saved value
+  const parentRssdValue = watch(parentRssd);
+  const topHolderRssdValue = watch(topHolderRssd);
+
   return (
     <FormSectionWrapper>
       <SectionIntro heading={heading}>
@@ -41,11 +54,11 @@ function UpdateAffiliateInformation({
         <InputEntry
           label={InstitutionDataLabels.rssd}
           helperText={InstitutionHelperText.rssd}
-          id='parent_rssd_id'
-          type='number'
-          {...register('parent_rssd_id', {
+          id={parentRssd}
+          {...register(parentRssd, {
             setValueAs: processRssdId,
           })}
+          value={parentRssdValue}
           errorMessage={formErrors.parent_rssd_id?.message}
           showError
         />
@@ -73,11 +86,11 @@ function UpdateAffiliateInformation({
         <InputEntry
           label={InstitutionDataLabels.rssd}
           helperText={InstitutionHelperText.rssd}
-          id='top_holder_rssd_id'
-          type='number'
-          {...register('top_holder_rssd_id', {
+          id={topHolderRssd}
+          {...register(topHolderRssd, {
             setValueAs: processRssdId,
           })}
+          value={topHolderRssdValue}
           errorMessage={formErrors.top_holder_rssd_id?.message}
           showError
         />

--- a/src/pages/Filing/UpdateFinancialProfile/UpdateIdentifyingInformation.tsx
+++ b/src/pages/Filing/UpdateFinancialProfile/UpdateIdentifyingInformation.tsx
@@ -76,7 +76,6 @@ function UpdateIdentifyingInformation({
           id={rssdID}
           label={InstitutionDataLabels.rssd}
           helperText={InstitutionHelperText.rssd}
-          type='number'
           {...register(rssdID, {
             setValueAs: processRssdId,
           })}


### PR DESCRIPTION
Closes #379

## Changes

- Make RSSD input fields `type='text'` to remove increment/decrement arrows
- Add workaround to keep displayed field value in sync with RHF data store

## How to test this PR

1. Visit Update institution profile page
2. Try to enter non-numbers in an RSSD ID field
3. Verify that the increment/decrement arrows are not displayed when the field is focused

## Screenshots
<img width="775" alt="Screenshot 2024-04-03 at 3 04 30 PM" src="https://github.com/cfpb/sbl-frontend/assets/2592907/a47b3932-1f35-4695-ae1d-ee0d44179ae5">

## Notes
- @natalia-fitzgerald Very large numbers cause the input value to be oddly parsed (ex. `2142333345222222311111` becomes `2.1423333452222224e+21`).  I couldn't find a definition online of RSSD ID that explains any restrictions or limits on length/size, so we'll need to follow up with the data folks for further guidance here. 
