### PR TITLE
Add `dependabot.yml` for version update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds the [`dependabot.yml`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) config file, which defines which package types dependabot should look for update for, and on what schedule.

We noticed that when we added CodeQL and dependabot at the same time that it threw some errors. Seems like we need to merge CodeQL first (#468), _then_ this PR. 

**Note:** This is our first time setting up dependabot with `package-ecosystem: "npm"`. We assume it will work very similar to our Python projects, but we won't know until with give it a try.

**Note:** The `npm` package type also supports `yarn`. See [`package-ecosystem`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) docs.