### PR TITLE
feat: source from ghcr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.20-alpine3.17 as build-stage
+FROM ghcr.io/cfpb/regtech/sbl/nodejs-alpine:3.18 as build-stage
 WORKDIR /usr/src/app
 ARG DOCKER_TAG="latest"
 
@@ -8,7 +8,7 @@ COPY / /usr/src/app
 RUN yarn install
 RUN yarn build
 
-FROM nginx:1.24-alpine
+FROM ghcr.io/cfpb/regtech/sbl/nginx-alpine:1.24
 ENV NGINX_USER=svc_nginx_sbl
 RUN apk update; apk upgrade
 RUN rm -rf /etc/nginx/conf.d


### PR DESCRIPTION
In an effort to improve our security posture, reference hardened image.

## Changes

- Changed FROM value in the Dockerfile to pull from hardened ghcr images.

## How to test this PR

1. Built the Dockerfile following the change
2. Pushed sbl-frontend hardened image to ECR
3. Updated devpub-cd-eval's sbl-frontend deployment to reference new hardened image tag
4. Ensured the sbl-frontend deployed and was available

