### PR TITLE
fix: [Sign & submit] Fix link double-underline

### DIFF
--- a/src/pages/Filing/FilingApp/FilingSubmit.tsx
+++ b/src/pages/Filing/FilingApp/FilingSubmit.tsx
@@ -294,7 +294,6 @@ export function FilingSubmit(): JSX.Element {
                 <Link
                   href='mailto:SBLHelp@cfpb.gov?subject=[BETA] Sign and submit: Feedback'
                   type='list'
-                  className='a-btn__link'
                 >
                   email our support staff
                 </Link>{' '}


### PR DESCRIPTION
Close #564 

## Changes
- Removes the double underline on the `email our support staff` link

## Screenshots
|Before|After|
|---|---|
|<img width="734" alt="Screenshot 2024-05-22 at 10 07 18 AM" src="https://github.com/cfpb/sbl-frontend/assets/2592907/46c49fea-232d-4eef-a735-212660d02a6a">|<img width="732" alt="Screenshot 2024-05-22 at 10 07 27 AM" src="https://github.com/cfpb/sbl-frontend/assets/2592907/1689fe16-3d20-4106-bdd7-c5df8f6e9740">|

