### PR TITLE
fix(start.sh): add profile support

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -90,7 +90,7 @@ fi
 ###### 3.) Run "docker compose up -d" in the "sbl-project" repo ######
 
 cd sbl-project
-docker compose up -d --build
+docker compose --profile="backend" up -d --build
 
 # Check the exit code of the previous command
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Changes

- `docker compose up -d --build` to `docker compose --profile="backend" up -d --build` to support the new profiles Jason added

## How to test this PR

1. does start.sh work now?