### PR TITLE
Step Indicator styles

### DIFF
--- a/src/components/InputEntry.tsx
+++ b/src/components/InputEntry.tsx
@@ -56,7 +56,7 @@ const InputEntry = forwardRef<HTMLInputElement, InputEntryProperties>(
                   {isOptional ? <LabelOptional /> : null}
                 </Heading>
                 {helperText ? (
-                  <div className='my-[0.625rem] max-w-[41.875rem] text-labelHelper'>
+                  <div className='my-[0.625rem] max-w-[41.875rem] text-grayDark'>
                     {helperText}
                   </div>
                 ) : null}

--- a/src/components/LabelOptional.tsx
+++ b/src/components/LabelOptional.tsx
@@ -1,6 +1,6 @@
 function LabelOptional(): JSX.Element {
   return (
-    <span className='text-base font-normal text-labelHelper'> (optional)</span>
+    <span className='text-base font-normal text-grayDark'> (optional)</span>
   );
 }
 

--- a/src/components/StepIndicator.tsx
+++ b/src/components/StepIndicator.tsx
@@ -24,9 +24,9 @@ export const mockSteps: StepType[] = [
 ];
 
 export const stepStyleMap = {
-  [STEP_COMPLETE]: 'border-stepIndicatorComplete font-medium text-black',
-  [STEP_CURRENT]: 'border-pacific font-semibold text-black',
-  [STEP_INCOMPLETE]: 'border-stepIndicatorIncomplete font-normal text-grayDark',
+  [STEP_COMPLETE]: 'border-navy font-medium text-black',
+  [STEP_CURRENT]: 'border-pacific font-medium text-black',
+  [STEP_INCOMPLETE]: 'border-gray20 font-medium text-grayDark',
 };
 
 export const screenReaderStatusMap = {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,13 +12,12 @@ const config = {
         successColor: '#20AA3F',
         disabledColor: '#E7E8E9',
         cfpbBorderColor: '#919395',
-        stepIndicatorComplete: '#254B87',
-        stepIndicatorIncomplete: '#D2D3D5',
-        labelHelper: '#43484E',
         black: '#101820',
+        gray20: '#D2D3D5',
         grayDark: '#43484E',
         pacific: '#0072CE', // TODO: Integrate DS color vars
         teal: '#257675',
+        navy: '#254B87',
       },
       fontFamily: {
         inter: ['Inter', ...defaultConfig.theme.fontFamily.sans],


### PR DESCRIPTION
Close #612 

## Changes

- Add Tailwind variables for DS colors: gray20, navy
- Adjust step font weights (all medium[500])
- Remove poorly named Tailwind color variables

## Screenshots
|When|Shot|
|---|---|
|Before|<img width="1237" alt="Screenshot 2024-06-03 at 12 53 05 PM" src="https://github.com/cfpb/sbl-frontend/assets/2592907/f184996a-2129-4cd5-89c7-279bc5530d25">|
|After|<img  alt="Screenshot 2024-06-03 at 12 44 41 PM" src="https://github.com/cfpb/sbl-frontend/assets/2592907/20cbef1d-c66a-4bf1-823c-23942a362bea">|


