### PR TITLE
fix(Filing home): Render error alert when cannot load associated institutions

### DIFF
--- a/src/pages/AuthenticatedLanding/ReviewInstitutions.tsx
+++ b/src/pages/AuthenticatedLanding/ReviewInstitutions.tsx
@@ -18,10 +18,16 @@ export function ReviewInstitutions({
     institutionList = (
       <AssociatedInstitutionList className={sharedStyles}>
         <Alert
-          isFieldLevel
           key='query-error'
           status='error'
           message='There was an error loading your associated financial institutions'
+          className='mt-[1.875rem]'
+          links={[
+            {
+              href: 'mailto:SBLHelp@cfpb.gov?subject=[BETA] Filing app: Error loading associated institutions',
+              label: 'Email our support staff',
+            },
+          ]}
         />
       </AssociatedInstitutionList>
     );


### PR DESCRIPTION
Close #648 

## Changes

- Updates alert to be form-level and to include email link

## How to test this PR

1. Force [this line](https://github.com/cfpb/sbl-frontend/pull/649/files#diff-b9b9bcc791f1f8ebbb7941cf10f99a41746a32ca2282c4a9c870e599ea6ca62bR17) to be `if (true)`
2. Visit `/landing` page
3. Confirm alert matches design file

## Screenshots
![updated-error--loading-associated-institutions](https://github.com/cfpb/sbl-frontend/assets/2592907/ba3d8ba6-d470-4a89-9ddd-8d358b06a5fd)


