### PR TITLE
fix(filing-home): update content for clearance

### DIFF
--- a/src/pages/Filing/FilingApp/InstitutionCard.helpers.ts
+++ b/src/pages/Filing/FilingApp/InstitutionCard.helpers.ts
@@ -72,7 +72,7 @@ export function deriveCardContent({
     case FilingStatusAsString.SUBMISSION_STARTED: {
       title = 'Upload your lending data';
       description =
-        'You will be asked to select a file to upload. We will perform validation checks on your register to ensure that data entries are correct and ready to submit.';
+        'You will be asked to select a file to upload. We will perform validation checks on your register to ensure that data entries do not contain errors and are ready to submit.';
 
       mainButtonLabel = 'Continue filing';
       mainButtonDestination = `/filing/${filingPeriod}/${lei}/upload`;
@@ -85,7 +85,7 @@ export function deriveCardContent({
     case FilingStatusAsString.VALIDATION_WITH_ERRORS: {
       title = 'Resolve errors in your lending data';
       description =
-        'Your file was successfully uploaded and validation checks returned errors. If applicable, make corrections to your register and upload a new file.';
+        'Your file was successfully uploaded but validation checks returned errors. If applicable, make corrections to your register and upload a new file.';
 
       mainButtonLabel = 'Continue filing';
       mainButtonDestination = `/filing/${filingPeriod}/${lei}/errors`;
@@ -111,7 +111,7 @@ export function deriveCardContent({
     case POINT_OF_CONTACT: {
       title = 'Provide point of contact';
       description =
-        'Your file has passed error validation checks and any warnings have been resolved or verified. Next, provide a point of contact for your submission.';
+        'You have completed the validation steps. Next, provide the contact information of a person that the Bureau or other regulators may contact with questions about your submission.';
 
       mainButtonLabel = 'Continue filing';
       mainButtonDestination = `/filing/${filingPeriod}/${lei}/contact`;


### PR DESCRIPTION
**Part of the clearance review**

Updates to latest content based on pre-clearance review of the filing app.

I've added a test account to `sbl-test-accounts` to see all the different states for the filing home on the preview site at once, just contact me for the details if necessary.

Closes #659 

## Changes

- Pre-clearance --- Update body text in "Upload your lending data" card
- Pre-clearance --- Update body text in "Resolve errors in your lending data" card
- Pre-clearance --- Update body text in "Provide point of contact" card

## Screenshots

### Pre-clearance --- Update body text in "Upload your lending data" card
|Before|After|
|---|---|
|![Before](https://github.com/cfpb/sbl-frontend/assets/19983248/78cf5fb8-f3c6-4e33-8c9a-5f1fefb459d5)|![After](https://github.com/cfpb/sbl-frontend/assets/19983248/7ef8a47f-807f-4215-8450-06d99409437f)|

### Pre-clearance --- Update body text in "Resolve errors in your lending data" card
|Before|After|
|---|---|
|![Before](https://github.com/cfpb/sbl-frontend/assets/19983248/52bd037e-9b85-4c32-986e-0e3f61b2cdc6)|![After](https://github.com/cfpb/sbl-frontend/assets/19983248/4acafc9e-f46b-434f-b84d-aa0056df5603)|

### Pre-clearance --- Update body text in "Provide point of contact" card
|Before|After|
|---|---|
|![Before](https://github.com/cfpb/sbl-frontend/assets/19983248/566c5f30-6ea4-4318-9ea9-c7c8027e5bcf)|![After](https://github.com/cfpb/sbl-frontend/assets/19983248/90274197-3ab0-4c31-af4f-64cbd2cfff0e)|
