### PR TITLE
fix(type-of-fi): update content for clearance

### DIFF
--- a/src/pages/Filing/UpdateFinancialProfile/TypesFinancialInstitutionSection.tsx
+++ b/src/pages/Filing/UpdateFinancialProfile/TypesFinancialInstitutionSection.tsx
@@ -50,6 +50,10 @@ function TypesFinancialInstitutionSection({
       <Heading type='4' id='sbl_institution_types'>
         Type of financial institution
       </Heading>
+      <div className='my-[0.9375rem] max-w-[41.875rem] text-grayDark'>
+        Select all applicable types of financial institutions from the list
+        below.
+      </div>
       {sectionError ? (
         <Paragraph>
           <Icon

--- a/src/pages/TypesFinancialInstitutions/index.tsx
+++ b/src/pages/TypesFinancialInstitutions/index.tsx
@@ -118,7 +118,9 @@ function TypesFinancialInstitutions(): JSX.Element {
               <Paragraph>
                 You must select at least one type of financial institution to
                 continue. This information is required pursuant to{' '}
-                <Links.RegulationB section='§ 1002.109(b)(9)' />.
+                <Links.RegulationB section='§ 1002.109(b)(9)' />. To update
+                other financial institution details,{' '}
+                <Links.UpdateInstitutionProfile />.
               </Paragraph>
             }
           />


### PR DESCRIPTION
**Part of the clearance review**

Updates Type of financial institution to latest content based on pre-clearance review of the filing app.

This does partly depend on PR #663 since it won't look exactly like figma without it.

Closes #661 


## Changes

- Pre-clearance -- Update intro body text link and double check rest of body content in the intro
- Pre-clearance -- Add helper text to "Type of financial institution" field set

## Screenshots

**This does partly depend on PR https://github.com/cfpb/sbl-frontend/pull/663 since it won't look exactly like figma without it.**

### Update intro body text link and double check rest of body content in the intro
|Before|After|
|---|---|
|![Before](https://github.com/cfpb/sbl-frontend/assets/19983248/836e8b25-5e99-40df-94c1-4ddeb890b331)|![After](https://github.com/cfpb/sbl-frontend/assets/19983248/81563b78-9a04-494e-92e1-fecd2f221521)|

### Add helper text to "Type of financial institution" field set
|Before|After|
|---|---|
|![Before](https://github.com/cfpb/sbl-frontend/assets/19983248/2f56fd9e-49b9-4569-91d3-02b8da0e6e4b)|![After](https://github.com/cfpb/sbl-frontend/assets/19983248/39d3b64c-5fdd-42ba-982f-1effe51a79f0)|