### PR TITLE
fix(auth): silent renew auth token between refreshes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,6 @@ import {
   Route,
   Routes,
   useLocation,
-  useNavigate,
 } from 'react-router-dom';
 import type { UserProfileType } from 'types/filingTypes';
 import getIsRoutingEnabled, {
@@ -119,7 +118,6 @@ function BasicLayout(): ReactElement {
       auth.signinSilent();
     });
   }, [auth.events, auth.signinSilent]);
-
 
   const isFilingPage = Boolean(location.pathname.startsWith('/filing/'));
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -111,7 +111,6 @@ function BasicLayout(): ReactElement {
   const location = useLocation();
 
   const auth = useSblAuth();
-  const navigate = useNavigate();
 
   // TODO: re-evaluate this useEffect / silent renew strategies post-mvp
   // see: https://github.com/cfpb/sbl-frontend/issues/696

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,13 +113,11 @@ function BasicLayout(): ReactElement {
   const auth = useSblAuth();
   const navigate = useNavigate();
 
+  // TODO: re-evaluate this useEffect / silent renew strategies post-mvp
+  // see: https://github.com/cfpb/sbl-frontend/issues/696
   useEffect(() => {
     return auth.events.addAccessTokenExpiring(() => {
-      try {
-        auth.signinSilent();
-      } catch (error) {
-        navigate('/');
-      }
+      auth.signinSilent();
     });
   }, [auth.events, auth.signinSilent]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import FilingWarnings from 'pages/Filing/FilingApp/FilingWarnings';
 import UpdateFinancialProfile from 'pages/Filing/UpdateFinancialProfile';
 import ViewUserProfile from 'pages/Filing/ViewUserProfile';
 import type { ReactElement } from 'react';
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, useEffect } from 'react';
 import {
   BrowserRouter,
   Navigate,
@@ -30,6 +30,7 @@ import {
   Route,
   Routes,
   useLocation,
+  useNavigate,
 } from 'react-router-dom';
 import type { UserProfileType } from 'types/filingTypes';
 import getIsRoutingEnabled, {
@@ -108,6 +109,20 @@ export function NavItem({
 function BasicLayout(): ReactElement {
   const headerLinks = [...useHeaderAuthLinks()];
   const location = useLocation();
+
+  const auth = useSblAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    return auth.events.addAccessTokenExpiring(() => {
+      try {
+        auth.signinSilent();
+      } catch (error) {
+        navigate('/');
+      }
+    });
+  }, [auth.events, auth.signinSilent]);
+
 
   const isFilingPage = Boolean(location.pathname.startsWith('/filing/'));
 


### PR DESCRIPTION
We were seeing testers during bug bashes hit 403s when sitting on the upload page for more than 10 minutes. This is a hotfix meant to fix this bug for the beta / next bug bash on Friday, but the react-oidc-context library will be revisited after launch. A lot of people have this issue it seems when users idle on a page, with the most common approach being to pop up an alert or use the approach I do in this PR: silently renewing the tokens if they expire. I'd rather lean on just automaticSilentRenew, and I think it may work in later versions of the library if we upgraded, but I'd like to fix it for now for the next bug bash then do a more thorough look at the automaticSilentRenew behavior when we get more time.

The obvious problem with this implementation is that currently this causes a re-render when a user's token expires (if they sit on the same page for 10 minutes). I think it's probably a mix of the useEffect but also maybe our config generally. I'd like to dig in a little deeper, but for now, let's fix it and then go back and try upgrading / creating a more nuanced auth strategy (maybe even upload page specific) after the next bug bash / post-mvp. I'm also going to ask that we bump the timeout to 15 minutes, and I think this issue will be mostly solved in the short-term. Here's https://github.com/cfpb/sbl-frontend/issues/696 for post-mvp work, and I might explore a more refined solution just for the upload page later.

Closes #695 

## Changes

- adds a silent renewal of our auth tokens if they expire between page loads

## How to test this PR

1. Sit on the upload page for 15 minutes, your token expires, but the token refreshes and you can still perform actions.
