### PR TITLE
fix(upload): retry upload, reenable backoff

### DIFF
--- a/src/api/requests/fetchFilingSubmissionLatest.ts
+++ b/src/api/requests/fetchFilingSubmissionLatest.ts
@@ -86,13 +86,10 @@ async function retryRequestWithDelay(
   }
 
   return new Promise(resolve => {
-    // NOTE: Set to one second for AWS load testing, will revert before mvp
-    // https://github.com/cfpb/sbl-frontend/issues/497
-    // setTimeout(
-    //   () => resolve(axiosInstance(response.config)),
-    //   getRetryDelay(axiosInstance.defaults.retryCount),
-    // );
-    setTimeout(() => resolve(axiosInstance(response.config)), STANDARD_TIMEOUT);
+    setTimeout(
+      () => resolve(axiosInstance(response.config)),
+      getRetryDelay(axiosInstance.defaults.retryCount),
+    );
   });
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,6 +5,7 @@ export const NegativeOne = -1;
 export const One = 1;
 export const Two = 2;
 export const MAX_RETRIES = 3;
+export const UPLOAD_CSV_MAX_RETRIES = 2;
 export const Five = 5;
 export const Ten = 10;
 export const ITEMS_PER_PAGE = 20;

--- a/src/utils/useUploadMutation.tsx
+++ b/src/utils/useUploadMutation.tsx
@@ -5,7 +5,10 @@ import useSblAuth from 'api/useSblAuth';
 import type { AxiosError } from 'axios';
 import type { FilingPeriodType, SubmissionResponse } from 'types/filingTypes';
 import type { InstitutionDetailsApiType } from 'types/formTypes';
-import { FILE_SIZE_LIMIT_ERROR_MESSAGE } from './constants';
+import {
+  FILE_SIZE_LIMIT_ERROR_MESSAGE,
+  UPLOAD_CSV_MAX_RETRIES,
+} from './constants';
 
 interface UploadMutationProperties {
   file: File;
@@ -42,6 +45,7 @@ const useUploadMutation = ({
       if (onSuccessCallback) void onSuccessCallback(data);
     },
     onError: error => {},
+    retry: UPLOAD_CSV_MAX_RETRIES,
   });
 };
 


### PR DESCRIPTION
At the bug bash on Wednesday, we decided to:
- re-enable the exponential backoff
- the frontend should retry on the assortment of 500s, 400s, etc, particularly for anything related to uploading files

1. re-enable the exponential backoff
re-enabled the code, removed the comment since we can use @shindigira's `MAX_RETRY_DELAY` instead.

2. the frontend should retry on the assortment of 500s, 400s, etc, particularly for anything related to uploading files
#711 adds retries to useQueries that were missing it, but when I was testing it last night, the `/submissions` POST was erroring out with some regularity.

![Screenshot 2024-06-13 at 8 05 49 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/12140580-d5a1-42e3-88e4-ca4f88734171)

This particular POST isn't a danger to retry on error: we're not in danger of putting the user into a weird state (just another submission as a worst case). But I did make a separate retry constant for it `UPLOAD_CSV_MAX_RETRIES`, since I don't want the user to sit around forever and we'll probably tweak this value.

Closes: #497 

## Changes

- re-enable exponential backoff
- retry uploading csv files up to a max of `UPLOAD_CSV_MAX_RETRIES` (2)

## How to test this PR

1. Lots of ways of forcing errors, but I prefer just doing it in the browser by [using request blocking](https://developer.chrome.com/docs/devtools/network-request-blocking):

2. Navigate to the upload page and try a submission.
3. Block the submission url in the network tab

<img width="474" alt="Screenshot 2024-06-14 at 10 51 21 AM" src="https://github.com/cfpb/sbl-frontend/assets/19983248/5bfe20c4-59f9-4b4e-8176-f9a53e607d78">


5. Try to upload a file again and notice the retries in the network tab

<img width="1309" alt="Screenshot 2024-06-14 at 10 54 52 AM" src="https://github.com/cfpb/sbl-frontend/assets/19983248/a7005da0-827b-452f-8e0d-cbb2f42ff190">


1. You could also force errors in the code like @shindigira [did over here](https://github.com/cfpb/sbl-frontend/pull/711#pullrequestreview-2116830081) but with the upload endpoint.
