### PR TITLE
fix: [Upload] Style the Upload button as "secondary" once a user has completed an upload

### DIFF
--- a/src/pages/Filing/FilingApp/FileSubmission.tsx
+++ b/src/pages/Filing/FilingApp/FileSubmission.tsx
@@ -335,7 +335,7 @@ export function FileSubmission(): JSX.Element {
                     disabled={isLoadingUpload || isFetchingGetSubmissionLatest}
                   />
                   <Button
-                    appearance='primary'
+                    appearance={disableButtonCriteria ? 'primary' : 'secondary'}
                     onClick={onHandleUploadClick}
                     label={buttonLabel}
                     aria-label={inputAriaLabel}


### PR DESCRIPTION
Close #725 

- If user has not yet submitted a file, the `Upload` button is primary and `Save and continue` is secondary
- Once an upload is completed, the `Upload` button is secondary and `Save and continue` is primary

https://github.com/cfpb/sbl-frontend/assets/2592907/1ef58157-000b-4153-ade2-b42f632e52f3

