### PR TITLE
fix(security): re-enable var injection

### DIFF
--- a/nginx-entrypoint.sh
+++ b/nginx-entrypoint.sh
@@ -4,19 +4,13 @@ set -e # Exit immediately if a command exits with a non-zero status
 # Use import-meta-env-alpine to inject environment variables
 cd /usr/share/nginx/html
 
-# reset env variable injection if already performed to allow container 
-# restarts with new variables
-[[ -e index.html.bak ]] && cp index.html.bak index.html
 
 # inject non-secret, public env variables into index.html
-./import-meta-env-alpine -x .env.example -p index.html || exit 1
+./import-meta-env-alpine -x .env.example -p index.html --disposable || exit 1
 
-# create nginx.conf with env vars from template
-# must specify variables to be substituted to avoid replacing base nginx vars
+# # create nginx.conf with env vars from template
+# # must specify variables to be substituted to avoid replacing base nginx vars
 envsubst \$SBL_REGTECH_BASE_URL < /etc/nginx/templates/nginx.conf.template > /etc/nginx/nginx.conf
-
-# start nginx as non-root user
-su -s /bin/ash svc_nginx_sbl
 
 # start nginx
 nginx -g "daemon off;"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -30,8 +30,13 @@ http {
   # Enable HSTS
   add_header Strict-Transport-Security 'max-age=31536000; includeSubDomains; preload';
 
+  # When being served locally, add the localhost domain to the CSP
+  map $SBL_REGTECH_BASE_URL $cfpb_domains {
+    ~localhost  "https://*.cfpb.gov localhost:*";
+    default     "https://*.cfpb.gov";
+  }
   # CSP
-  add_header Content-Security-Policy "default-src 'self' blob:; script-src 'self' 'unsafe-inline' blob: data: https://tagmanager.google.com https://www.googletagmanager.com https://www.google-analytics.com https://*.cfpb.gov https://www.consumerfinance.gov https://cdn.mouseflow.com; img-src 'self' blob: data: https://www.google-analytics.com https://raw.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; frame-src 'self' https://www.youtube.com/ https://ffiec.cfpb.gov/; connect-src 'self' https://*.cfpb.gov https://www.consumerfinance.gov https://raw.githubusercontent.com https://ffiec-api.cfpb.gov https://ffiec.cfpb.gov https://*.mapbox.com https://www.google-analytics.com https://s3.amazonaws.com http://*.algolia.net https://stats.g.doubleclick.net;";
+  add_header Content-Security-Policy "default-src 'self' blob:; script-src 'self' 'unsafe-inline' blob: data: ${cfpb_domains} https://tagmanager.google.com https://www.googletagmanager.com https://www.google-analytics.com https://www.consumerfinance.gov https://cdn.mouseflow.com; img-src 'self' blob: data: https://www.google-analytics.com https://raw.githubusercontent.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; object-src 'none'; frame-src 'self' https://www.youtube.com/ https://ffiec.cfpb.gov/; connect-src 'self' ${cfpb_domains} https://www.consumerfinance.gov https://raw.githubusercontent.com https://ffiec-api.cfpb.gov https://ffiec.cfpb.gov https://*.mapbox.com https://www.google-analytics.com https://s3.amazonaws.com http://*.algolia.net https://stats.g.doubleclick.net;";
 
   # Restrict referrer
   add_header Referrer-Policy "strict-origin";


### PR DESCRIPTION
Re-enables env var injection, while still conforming to the evidence collection script (it appears running it only produces changes in timestamps).

## Changes

- utilized the service account inside of the entrypoint, instead of switching to the service account when in the entrypoint
- disables the container bouncing feature for simpler permissions handling 

## How to test this PR

1. Does the evidence collection still pass, but now you can inject vars into the frontend?
