### PR TITLE
fix(csp): adds nonce to import-meta-env script

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,8 +50,8 @@
     <!-- End Google Tag Manager (noscript) -->
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!-- import-meta-env env var injection occurs below for production builds / cache busting -->
-    <script>
+    <!-- import-meta-env public env var injection occurs below for builds / cache busting -->
+    <script nonce="nonce-placeholder">
       globalThis.import_meta_env = JSON.parse('"import_meta_env_placeholder"');
     </script>
     <script type="module" src="/src/main.tsx"></script>


### PR DESCRIPTION
We'll need to add the `nonce` tag to the [import-meta-env](https://import-meta-env.org/) script, otherwise it doesn't run in production.

## Changes

- adds nonce to import-meta-env
- adjusts comment a bit to emphasize public env vars

## How to test this PR

1. Go onto the preview site and try to login. If it works, then this is working. 👍

## Screenshots
![Screenshot 2024-06-23 at 7 00 40 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/002238fd-a050-4f4d-90ae-679fdc13d700)
