### PR TITLE
fix(axios): keep auth token in sync with oidc token

### DIFF
--- a/src/api/requests/fetchFilingSubmissionLatest.ts
+++ b/src/api/requests/fetchFilingSubmissionLatest.ts
@@ -1,5 +1,8 @@
-import { getAxiosInstance, request } from 'api/axiosService';
-import { FILING_URL, VALIDATION_TIMEOUT_SECONDS } from 'api/common';
+import {
+  fetchFilingSubmissionLatestApiClient as apiClient,
+  request,
+} from 'api/axiosService';
+import { VALIDATION_TIMEOUT_SECONDS } from 'api/common';
 import type { SblAuthProperties } from 'api/useSblAuth';
 import type { AxiosResponse } from 'axios';
 import { AxiosError } from 'axios';
@@ -36,8 +39,6 @@ function getRetryDelay(retry = Zero): number {
     MAX_RETRY_DELAY, // 15 seconds
   );
 }
-
-const apiClient: AxiosInstanceExtended = getAxiosInstance(FILING_URL);
 
 export function getMaxRetriesAxiosError(response: AxiosResponse): AxiosError {
   // Order of parameters: 'message', 'code', 'config', 'request', 'response'

--- a/src/utils/getOidcTokenOutsideContext.ts
+++ b/src/utils/getOidcTokenOutsideContext.ts
@@ -1,0 +1,27 @@
+import type { User } from 'oidc-client-ts';
+
+/**
+ * Retrieves the oidc token from the session storage outside of the AuthProvider context
+ * @returns The oidc token as a string or null if it does not exist
+ */
+const getOidcTokenOutsideOfContext = (): string | null => {
+  const oidcSessionStorageName = Object.keys(sessionStorage).find(
+    key =>
+      /*  gets the oidc session storage, and the current environment check is only needed if a
+    a dev changes their .env file locally without closing the tab */
+      key.startsWith('oidc.user') &&
+      key.includes(import.meta.env.SBL_OIDC_AUTHORITY),
+  );
+  if (!oidcSessionStorageName) return null;
+
+  const sessionStorageOidcString = sessionStorage.getItem(
+    oidcSessionStorageName,
+  );
+  if (!sessionStorageOidcString) return null;
+
+  const sessionStorageOidc = JSON.parse(sessionStorageOidcString) as User;
+  const accessToken = `Bearer ${sessionStorageOidc.access_token}`;
+  return accessToken;
+};
+
+export default getOidcTokenOutsideOfContext;


### PR DESCRIPTION
Based on my testing, this fixes the remaining problems with 403s.

[This PR](https://github.com/cfpb/sbl-frontend/pull/738) updated the react-oidc-context library so that the iframe auth injection worked when `automaticSilentRenew` was enabled and let the token be updated in between page views without any re-renders.

Now we've got another problem that this PR fixes: react query. When the auth token gets refreshed, any query will continue to use the old auth token unless we add it to the `queryFn`. That totally works, but will cause a re-render unless we pepper the codebase with `useMemo`s and `useCallback`s, that I don't want to do until we upgrade to React 19 post-mvp and React Compiler [does it for us](https://react.dev/learn/react-compiler).

So where does that leave us? The internet generally recommends either biting the bullet with the re-renders, or retrying with the correct authentication token and then persisting that token for future calls in either react query or an axios interceptor, or just use the axios interceptor to do the authentication entirely. I liked the 3rd option because having to retry on errors you know are coming makes me sad (like the 50x errors we have), and I think this is the cleaner method without relying on tricky state management and react query wrangling to avoid re-renders. I've [made a ticket](https://github.com/cfpb/sbl-frontend/issues/752) to potentially strip auth from our queries if this PR gets approved and works.

So this axios interceptor, in conjunction with the fact that iframe auth injection works and writes to session storage, uses the session storage to add the auth token to the api calls. Session storage is fast and lets the function live outside the AuthContext and be applied to any call. This means that the api calls are always using the latest auth token regardless of their react query set up, and does so without triggering re-renders.

## Future PRS
- [remove auth from existing queries if this PR works](https://github.com/cfpb/sbl-frontend/issues/752)
- [add a catch all auth error on 403s/401s to redirect to the unauthenticated home page (if a user closes their laptop lid for 30 mins for example)](https://github.com/cfpb/sbl-frontend/issues/753)

## Changes

- modify `getAxiosInstance` to include an interceptor that adds auth tokens from session storage to each call
- update `fetchFilingSubmissionLatest.ts` to use the modified `getAxiosInstance` function instead of creating its own so that the interceptor gets added
- create a getOidcTokenOutsideContext.ts utility function that pulls the oidc token from session storage

## How to test this PR

This PR depends on:
https://github.com/cfpb/sbl-frontend/pull/750
https://github.com/cfpb/sbl-frontend/pull/738

You can test this PR locally by pointing your local env to the preview env or by testing it on the preview environment itself (check with Bill to make sure it's up on preview still)

1. Navigate to the [regtech realm settings for tokens](http://localhost:8880/admin/master/console/#/regtech/realm-settings/tokens). Change the Access Token Lifespan to 65 seconds. (oidc-client-ts [tries to renew a token one minute](https://github.com/authts/oidc-client-ts/blob/0d9dd56/src/UserManagerSettings.ts#L52C117-L52C209) before the expiration time, so this will make the frontend seek a new token every five seconds)
![Screenshot 2024-06-19 at 1 51 42 PM](https://github.com/cfpb/sbl-frontend/assets/19983248/c339cb1c-bc20-4ccc-9903-e5ecf84b318b)
3. Go to the upload page and try to upload a large file with your network tab open.
4.Notice that after each time the token is refreshed in the network tab, that the `/latest` API call's authentication token is also updated to reflect that change. (see Screenshots)
5. Notice that there are maybe no more 403s? 🤞

## Screenshots
![before-refresh](https://github.com/cfpb/sbl-frontend/assets/19983248/9cce2586-8416-4d60-a7b5-437f44ede20e)
![token-refreshed](https://github.com/cfpb/sbl-frontend/assets/19983248/edf20e56-dceb-4173-b224-89246032657c)
![after-refresh](https://github.com/cfpb/sbl-frontend/assets/19983248/7c040f95-350f-4863-912f-87955b2dca49)
