### PR TITLE
Open external links in new tab

### DIFF
--- a/src/components/CommonLinks.tsx
+++ b/src/components/CommonLinks.tsx
@@ -4,11 +4,7 @@ import type { ReactElement } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 function GLIEF(): ReactElement {
-  return (
-    <Link href='https://www.gleif.org/' target='_blank'>
-      GLEIF
-    </Link>
-  );
+  return <Link href='https://www.gleif.org/'>GLEIF</Link>;
 }
 
 function GetAnLEI(): ReactElement {
@@ -20,11 +16,7 @@ function GetAnLEI(): ReactElement {
 }
 
 function NIC(): ReactElement {
-  return (
-    <Link href='https://www.ffiec.gov/NPW' target='_blank'>
-      NIC
-    </Link>
-  );
+  return <Link href='https://www.ffiec.gov/NPW'>NIC</Link>;
 }
 
 interface UpdateInstitutionProfileProperties {
@@ -105,11 +97,7 @@ function RegulationB({
   ] satisfies RegulationBSectionUrlsValues;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!sectionUrl) return section as unknown as JSX.Element;
-  return (
-    <Link href={baseUrl + sectionUrl} target='_blank'>
-      {section}
-    </Link>
-  );
+  return <Link href={baseUrl + sectionUrl}>{section}</Link>;
 }
 
 function EmailSupportStaff({
@@ -126,10 +114,7 @@ function EmailSupportStaff({
   const formattedSubject = (isBeta ? '[BETA] ' : '') + subject;
 
   return (
-    <Link
-      href={`mailto:SBLHelp@cfpb.gov?subject=${formattedSubject}`}
-      target='_blank'
-    >
+    <Link href={`mailto:SBLHelp@cfpb.gov?subject=${formattedSubject}`}>
       {label}
     </Link>
   );
@@ -137,10 +122,7 @@ function EmailSupportStaff({
 
 function FederalReserveBoard(): ReactElement {
   return (
-    <Link
-      href='https://www.federalreserve.gov/apps/reportingforms/Report/Index/FR_Y-10'
-      target='_blank'
-    >
+    <Link href='https://www.federalreserve.gov/apps/reportingforms/Report/Index/FR_Y-10'>
       Federal Reserve Board
     </Link>
   );

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -54,11 +54,16 @@ export function Link({
   isRouterLink,
   ...others
 }: LinkProperties): JSX.Element {
+  const isInternalLink = getIsRouterLink(href, isRouterLink);
+  const otherProperties = { ...others };
+
+  if (!isInternalLink) otherProperties.target = '_blank'; // Open link in new tab
+
   return (
     <DesignSystemReactLink
       href={href}
-      isRouterLink={getIsRouterLink(href, isRouterLink)}
-      {...others}
+      isRouterLink={isInternalLink}
+      {...otherProperties}
     >
       {children}
     </DesignSystemReactLink>

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -45,6 +45,8 @@ interface LinkProperties extends DesignSystemReactLinkProperties {
   /* eslint-disable react/require-default-props */
   href?: string | undefined;
   isRouterLink?: boolean | undefined;
+  target?: string | undefined;
+
   /* eslint-enable react/require-default-props */
 }
 
@@ -55,7 +57,7 @@ export function Link({
   ...others
 }: LinkProperties): JSX.Element {
   const isInternalLink = getIsRouterLink(href, isRouterLink);
-  const otherProperties = { ...others };
+  const otherProperties: LinkProperties = { ...others };
 
   if (!isInternalLink) otherProperties.target = '_blank'; // Open link in new tab
 

--- a/src/pages/Filing/FilingApp/FieldEntry.tsx
+++ b/src/pages/Filing/FilingApp/FieldEntry.tsx
@@ -121,7 +121,7 @@ function FieldEntry({
   return (
     <div className='mb-[2.8125rem]'>
       <div className='validation-info-section mb-[1.875rem] max-w-[41.875rem]'>
-        <Link target='_blank' href={validationLink}>
+        <Link href={validationLink}>
           <Heading
             className='inline-block border-x-0 border-b-[1px] border-t-0 border-dotted hover:border-solid focus:border-solid focus:outline-dotted focus:outline-1'
             type='3'

--- a/src/pages/Filing/FilingApp/FilingErrors/FilingErrorsAlerts.tsx
+++ b/src/pages/Filing/FilingApp/FilingErrors/FilingErrorsAlerts.tsx
@@ -27,7 +27,7 @@ function SyntaxErrorsAlert(): JSX.Element {
         There may be an issue with the data type or format of one or more values
         in your file. Make sure your register meets the requirements detailed in
         the filing instructions guide (
-        <Link target='_blank' href={dataValidationLink}>
+        <Link href={dataValidationLink}>
           section 4, &quot;Data validation&quot;
         </Link>
         ), make the corrections, and upload a new file.
@@ -48,7 +48,7 @@ function LogicErrorsAlert(): JSX.Element {
         There is missing data, incorrect data, or conflicting information in
         your file. Make sure your register meets the requirements detailed in
         the filing instructions guide (
-        <Link target='_blank' href={dataValidationLink}>
+        <Link href={dataValidationLink}>
           section 4, &quot;Data validation&quot;
         </Link>
         ), make the corrections, and upload a new file.

--- a/src/pages/Filing/FilingApp/FilingOverviewPage.tsx
+++ b/src/pages/Filing/FilingApp/FilingOverviewPage.tsx
@@ -71,10 +71,7 @@ export default function FilingOverview(): ReactElement {
                 financial institutions,{' '}
                 <Links.EmailSupportStaff subject='Associated financial institutions' />
                 . For detailed filing specifications, reference the{' '}
-                <Link
-                  target='_blank'
-                  href='https://www.consumerfinance.gov/data-research/small-business-lending/filing-instructions-guide/2024-guide/'
-                >
+                <Link href='https://www.consumerfinance.gov/data-research/small-business-lending/filing-instructions-guide/2024-guide/'>
                   filing instructions guide for small business lending data
                 </Link>
                 .

--- a/src/pages/Filing/FilingApp/FilingWarnings/FilingWarningsAlerts.tsx
+++ b/src/pages/Filing/FilingApp/FilingWarnings/FilingWarningsAlerts.tsx
@@ -35,7 +35,7 @@ function WarningsAlert(): JSX.Element {
         Unexpected values were found in your register that may require action.
         Make sure your register meets the requirements detailed in the filing
         instructions guide (
-        <Link target='_blank' href={dataValidationLink}>
+        <Link href={dataValidationLink}>
           section 4, &quot;Data validation&quot;
         </Link>
         ). If necessary, make the corrections, and upload a new file.

--- a/src/pages/Filing/FilingApp/InstitutionCard.tsx
+++ b/src/pages/Filing/FilingApp/InstitutionCard.tsx
@@ -31,9 +31,7 @@ function SecondaryButton({
 
   return (
     <p className='ml-[0.9375rem] inline-block font-medium'>
-      <Link target='_blank' href={secondaryButtonDestination}>
-        {secondaryButtonLabel}
-      </Link>
+      <Link href={secondaryButtonDestination}>{secondaryButtonLabel}</Link>
     </p>
   );
 }

--- a/src/pages/Filing/FilingHome.tsx
+++ b/src/pages/Filing/FilingHome.tsx
@@ -35,12 +35,10 @@ function Home(): ReactElement {
               <Heading type='2'>Sign in with Login.gov</Heading>
               <Paragraph>
                 The CFPB participates with{' '}
-                <Link target='_blank' href={loginGovHomepage}>
-                  Login.gov
-                </Link>{' '}
-                to provide secure sign in and private access to your
-                information. You must sign in with an email address issued by
-                your financial institution to access the platform.
+                <Link href={loginGovHomepage}>Login.gov</Link> to provide secure
+                sign in and private access to your information. You must sign in
+                with an email address issued by your financial institution to
+                access the platform.
               </Paragraph>
               <Button
                 id='signin-button'

--- a/src/pages/ProfileForm/Step1Form/Step1FormHeader.tsx
+++ b/src/pages/ProfileForm/Step1Form/Step1FormHeader.tsx
@@ -26,14 +26,9 @@ function Step1FormHeader({ isStep1 }: Step1FormHeaderProperties): JSX.Element {
               In order to begin using the platform you must have a Legal Entity
               Identifier (LEI) for your financial institution. If your
               organization does not have an LEI, visit the{' '}
-              <Link href={gleifGetAnLEI} target='_blank'>
-                Global LEI Foundation (GLEIF)
-              </Link>{' '}
-              to get an LEI. If you need assistance with this form,{' '}
-              <Link
-                href='mailto:SBLHelp@cfpb.gov?subject=[BETA] Complete your user profile: Form assistance'
-                target='_blank'
-              >
+              <Link href={gleifGetAnLEI}>Global LEI Foundation (GLEIF)</Link> to
+              get an LEI. If you need assistance with this form,{' '}
+              <Link href='mailto:SBLHelp@cfpb.gov?subject=[BETA] Complete your user profile: Form assistance'>
                 email our support staff
               </Link>
               .

--- a/src/pages/Summary/Summary.data.tsx
+++ b/src/pages/Summary/Summary.data.tsx
@@ -90,7 +90,7 @@ const linkStyles = 'border-b-[1px]';
 function ChildrenError1(): JSX.Element {
   return (
     <>
-      <Link className={linkStyles} href={loginGovAccountPage} target='_blank'>
+      <Link className={linkStyles} href={loginGovAccountPage}>
         Visit your Login.gov account page
       </Link>{' '}
       to confirm that your financial institution email address has been added to
@@ -104,7 +104,6 @@ function ChildrenError1(): JSX.Element {
       <Link
         className={linkStyles}
         href='mailto:SBLHelp@cfpb.gov?subject=[BETA] Complete your user profile: Questions after submitting form'
-        target='_blank'
       >
         email our support staff
       </Link>
@@ -123,7 +122,6 @@ function ChildrenWarning4(): JSX.Element {
       <Link
         className={linkStyles}
         href='mailto:SBLHelp@cfpb.gov?subject=[BETA] Complete your user profile: Questions after submitting form'
-        target='_blank'
       >
         email our support staff
       </Link>
@@ -140,7 +138,6 @@ function ChildrenSuccessInstitutionProfileUpdate(): JSX.Element {
       <Link
         className={linkStyles}
         href='mailto:SBLHelp@cfpb.gov?subject=[BETA] Update your financial institution profile: Questions after submitting form'
-        target='_blank'
       >
         email our support staff
       </Link>


### PR DESCRIPTION
Close #779 

## Changes

- Centralize logic to open external links in new tab
- Remove all explicit `target="_blank"`s

## How to test this PR

1. (internal) Visit authenticated landing page, click on an Institution in the `Review your FI profile` section; Should open in same tab
1. (external) Visit `Upload` page and click on the "filing instructions guide..." link, should open in new tab
 
