### PR TITLE
removed unsafe-inline and unsafe-eval from nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -44,8 +44,8 @@ http {
 
   # CSP
   add_header Content-Security-Policy "default-src 'self' blob:; 
-    script-src 'self' 'unsafe-inline' 'unsafe-eval' 'nonce-$request_id' blob: data: ${cfpb_domains} *.consumerfinance.gov dap.digitalgov.gov *.googleanalytics.com *.google-analytics.com *.googletagmanager.com *.mouseflow.com; 
-    style-src 'self' 'unsafe-inline' *.consumerfinance.gov *.googletagmanager.com fonts.googleapis.com; 
+    script-src 'self' 'nonce-$request_id' blob: data: ${cfpb_domains} *.consumerfinance.gov dap.digitalgov.gov *.googleanalytics.com *.google-analytics.com *.googletagmanager.com *.mouseflow.com; 
+    style-src 'self' *.consumerfinance.gov *.googletagmanager.com fonts.googleapis.com; 
     img-src 'self' *.consumerfinance.gov s3.amazonaws.com *.google-analytics.com *.googletagmanager.com blob: data: *.mouseflow.com; 
     frame-src 'self' *.consumerfinance.gov *.googletagmanager.com *.google-analytics.com mailto: *.mouseflow.com;
     font-src 'self' https://ffiec.cfpb.gov/ fonts.gstatic.com *.mouseflow.com;


### PR DESCRIPTION
closes #879 

## Changes
-Removed 'unsafe-inline' and 'unsafe-eval' from nginx CSP

## How to test
- Deploy on dev pub and check console messages