### PR TITLE
fix(content): mostly change submission to filing

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,13 +5,13 @@
     <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>
-      Small Business Lending Data Submission Platform | Consumer Financial
+      Small Business Lending Data Filing Platform | Consumer Financial
       Protection Bureau
     </title>
     <meta name="robots" content="noindex" />
     <meta
       name="description"
-      content="Use the CFPB small business lending data submission platform to upload your lending data, review validation results, and submit your filing."
+      content="Use the CFPB Small Business Lending Data Filing Platform to upload your lending data, review validation results, and submit your filing."
     />
     <meta name="theme-color" content="#42b883" />
     <!-- Google Tag Manager -->

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -150,7 +150,7 @@ function BasicLayout(): Promise<void> | ReactElement {
         <div className='o-banner'>
           <div className='wrapper wrapper__match-content'>
             <Alert
-              message='This is a beta for the small business lending data submission platform'
+              message='This is a beta for the Small Business Lending Data Filing Platform'
               status='warning'
             />
           </div>

--- a/src/api/requests/downloadValidationReport.ts
+++ b/src/api/requests/downloadValidationReport.ts
@@ -49,7 +49,7 @@ export const downloadValidationReport = async ({
       link.href = url;
       link.setAttribute(
         'download',
-        `${lei}-${filingPeriod}-submission-${submissionId}-validation_report.csv`,
+        `${lei}_${filingPeriod}_${submissionId}_validation_report.csv`,
       );
       document.body.append(link);
       link.click();

--- a/src/components/BetaAndLegalNotice.tsx
+++ b/src/components/BetaAndLegalNotice.tsx
@@ -9,14 +9,12 @@ export default function BetaAndLegalNotice(): ReactElement {
       message={
         <>
           <Heading type='2' className='h4 mb-[0.313rem]'>
-            This is a beta for the small business lending data submission
-            platform
+            This is a beta for the Small Business Lending Data Filing Platform
           </Heading>
           <Paragraph>
-            Thank you for participating. The data submission platform is
-            available to upload, test, and validate data. All uploaded data is
-            for testing purposes only and may be removed at any time. For
-            questions or feedback,{' '}
+            Thank you for participating. The platform is available to upload,
+            test, and validate data. All uploaded data is for testing purposes
+            only and may be removed at any time. For questions or feedback,{' '}
             <Link href='mailto:SBLHelp@cfpb.gov?subject=[BETA] Home page: Questions or feedback'>
               email our support staff
             </Link>

--- a/src/components/BetaAndLegalNotice.tsx
+++ b/src/components/BetaAndLegalNotice.tsx
@@ -12,9 +12,10 @@ export default function BetaAndLegalNotice(): ReactElement {
             This is a beta for the Small Business Lending Data Filing Platform
           </Heading>
           <Paragraph>
-            Thank you for participating. The platform is available to upload,
-            test, and validate data. All uploaded data is for testing purposes
-            only and may be removed at any time. For questions or feedback,{' '}
+            Thank you for participating. The beta platform is available to
+            upload, test, and validate data. All uploaded data is for testing
+            purposes only and may be removed at any time. For questions or
+            feedback,{' '}
             <Link href='mailto:SBLHelp@cfpb.gov?subject=[BETA] Home page: Questions or feedback'>
               email our support staff
             </Link>

--- a/src/components/FormErrorHeader.data.ts
+++ b/src/components/FormErrorHeader.data.ts
@@ -158,23 +158,23 @@ export type IdFormHeaderErrorsValues =
 // Point of Contact - Zod Schema Error Messages
 export const PocZodSchemaErrors = {
   firstNameMin:
-    'You must enter the first name of the point of contact for your submission.',
+    'You must enter the first name of the point of contact for your filing.',
   lastNameMin:
-    'You must enter the last name of the point of contact for your submission.',
+    'You must enter the last name of the point of contact for your filing.',
   phoneMin:
-    'You must enter the phone number of the point of contact for your submission.',
+    'You must enter the phone number of the point of contact for your filing.',
   phoneRegex: 'You must enter a valid phone number.',
   emailMin:
-    'You must enter the email address of the point of contact for your submission.',
+    'You must enter the email address of the point of contact for your filing.',
   emailRegex: 'You must enter a valid email address.',
   hq_address_street_1Min:
-    'You must enter the street address of the point of contact for your submission.',
+    'You must enter the street address of the point of contact for your filing.',
   hq_address_cityMin:
-    'You must enter the city of the point of contact for your submission.',
+    'You must enter the city of the point of contact for your filing.',
   hq_address_stateMin:
-    'You must select the state or territory of the point of contact for your submission.',
+    'You must select the state or territory of the point of contact for your filing.',
   hq_address_zipMin:
-    'You must enter the ZIP code of the point of contact for your submission.',
+    'You must enter the ZIP code of the point of contact for your filing.',
   hq_address_zipRegex: 'You must enter a valid ZIP code.',
 } as const;
 

--- a/src/pages/AuthenticatedLanding/ReviewInstitutions.tsx
+++ b/src/pages/AuthenticatedLanding/ReviewInstitutions.tsx
@@ -59,8 +59,8 @@ export function ReviewInstitutions({
       </Heading>
       <Paragraph>
         You are required to provide certain identifying information about your
-        associated financial institutions as part of your submission. Click on
-        your financial institution to view or update your financial institution
+        associated financial institutions as part of your filing. Click on your
+        financial institution to view or update your financial institution
         profile.
       </Paragraph>
       {institutionList}

--- a/src/pages/Filing/FilingApp/FilingSubmit.helpers.tsx
+++ b/src/pages/Filing/FilingApp/FilingSubmit.helpers.tsx
@@ -168,7 +168,7 @@ export function SignCertify({
           knowledge of the data must certify the accuracy and completeness of
           the data reported pursuant to{' '}
           <Links.RegulationB section='§ 1002.109(a)(1)(ii)' />. To complete your
-          official regulatory submission, check the box and submit your filing.
+          official regulatory filing, check the box and submit your filing.
         </p>
       </SectionIntro>
 

--- a/src/pages/Filing/FilingApp/FilingSubmit.tsx
+++ b/src/pages/Filing/FilingApp/FilingSubmit.tsx
@@ -148,7 +148,7 @@ export function FilingSubmit(): JSX.Element {
                 yourself with this step as it will be a part of the official
                 filing process. Note that all data uploaded to the beta platform
                 is for testing purposes only and may be removed at any time. If
-                you would like to continue testing the system,{' '}
+                you would like to continue testing the beta platform,{' '}
                 <Links.UploadANewFile />.
               </div>
             </Alert>
@@ -278,7 +278,7 @@ export function FilingSubmit(): JSX.Element {
             >
               <Paragraph>
                 Thank you for participating. Your input will help us improve our
-                beta platform. Take a moment to{' '}
+                platform. Take a moment to{' '}
                 <Link
                   href='mailto:SBLHelp@cfpb.gov?subject=[BETA] Sign and submit: Feedback'
                   type='list'

--- a/src/pages/Filing/FilingApp/FilingSubmit.tsx
+++ b/src/pages/Filing/FilingApp/FilingSubmit.tsx
@@ -148,7 +148,7 @@ export function FilingSubmit(): JSX.Element {
                 yourself with this step as it will be a part of the official
                 filing process. Note that all data uploaded to the beta platform
                 is for testing purposes only and may be removed at any time. If
-                you would like to continue testing the beta platform,{' '}
+                you would like to continue testing the platform,{' '}
                 <Links.UploadANewFile />.
               </div>
             </Alert>

--- a/src/pages/Filing/FilingApp/FilingSubmit.tsx
+++ b/src/pages/Filing/FilingApp/FilingSubmit.tsx
@@ -167,8 +167,8 @@ export function FilingSubmit(): JSX.Element {
                   {/* eslint-disable-line @typescript-eslint/no-unsafe-argument */}
                   {/* eslint-enable */}
                   {/* @ts-expect-error Part of code cleanup for post-mvp see: https://github.com/cfpb/sbl-frontend/issues/717 */}
-                  receipt number for this submission is {submission.filename}.
-                  Save this receipt number for future reference.
+                  receipt number for this filing is {submission.filename}. Save
+                  this receipt number for future reference.
                 </div>
               </Alert>
             ) : (

--- a/src/pages/Filing/FilingApp/FilingSubmit.tsx
+++ b/src/pages/Filing/FilingApp/FilingSubmit.tsx
@@ -146,9 +146,9 @@ export function FilingSubmit(): JSX.Element {
                 file upload and validations. In this final step, all
                 functionality has been disabled. We encourage you to familiarize
                 yourself with this step as it will be a part of the official
-                filing process. Note that all data uploaded to the platform is
-                for testing purposes only and may be removed at any time. If you
-                would like to continue testing the system,{' '}
+                filing process. Note that all data uploaded to the beta platform
+                is for testing purposes only and may be removed at any time. If
+                you would like to continue testing the system,{' '}
                 <Links.UploadANewFile />.
               </div>
             </Alert>
@@ -278,7 +278,7 @@ export function FilingSubmit(): JSX.Element {
             >
               <Paragraph>
                 Thank you for participating. Your input will help us improve our
-                platform. Take a moment to{' '}
+                beta platform. Take a moment to{' '}
                 <Link
                   href='mailto:SBLHelp@cfpb.gov?subject=[BETA] Sign and submit: Feedback'
                   type='list'

--- a/src/pages/Filing/FilingApp/InstitutionCard.helpers.ts
+++ b/src/pages/Filing/FilingApp/InstitutionCard.helpers.ts
@@ -111,7 +111,7 @@ export function deriveCardContent({
     case POINT_OF_CONTACT: {
       title = 'Provide point of contact';
       description =
-        'You have completed the validation steps. Next, provide the contact information of a person that the Bureau or other regulators may contact with questions about your submission.';
+        'You have completed the validation steps. Next, provide the contact information of a person that the Bureau or other regulators may contact with questions about your filing.';
 
       mainButtonLabel = 'Continue filing';
       mainButtonDestination = `/filing/${filingPeriod}/${lei}/contact`;

--- a/src/pages/Filing/FilingHome.tsx
+++ b/src/pages/Filing/FilingHome.tsx
@@ -158,8 +158,8 @@ function Home(): ReactElement {
             <Heading type='5'>Privacy Notice</Heading>
             <Paragraph>
               The Consumer Financial Protection Bureau (CFPB) is collecting data
-              to test the functionality of the small business lending data
-              submission platform.
+              to test the functionality of the Small Business Lending Data
+              Filing Platform.
             </Paragraph>
             <List className='mt-[1rem] list-none pl-0' isLinks>
               <ListLink href='/privacy-notice'>View Privacy Notice</ListLink>

--- a/src/pages/Filing/PrivacyNotice.tsx
+++ b/src/pages/Filing/PrivacyNotice.tsx
@@ -14,8 +14,8 @@ function PrivacyNotice(): ReactElement {
           </CrumbTrail>
           <TextIntroduction
             heading='Privacy Notice'
-            subheading='The Consumer Financial Protection Bureau (CFPB) is collecting data to test the functionality of the small business lending data submission platform.'
-            description='The testing will help ensure that the system can support the submission of data needed to enforce fair lending laws pursuant to Public Law No. 111-203, Title X, Section 1071, codified at 12 C.F.R. 1002. Participation is voluntary. If you choose to participate, the CFPB will collect your first and last name to test the "Complete your user profile" page. The CFPB will not use the data for any other purpose besides testing. Please do not submit any live data in the system.'
+            subheading='The Consumer Financial Protection Bureau (CFPB) is collecting data to test the functionality of the Small Business Lending Data Filing Platform.'
+            description='The testing will help ensure that the system can support the filing of data needed to enforce fair lending laws pursuant to Public Law No. 111-203, Title X, Section 1071, codified at 12 C.F.R. 1002. Participation is voluntary. If you choose to participate, the CFPB will collect your first and last name to test the "Complete your user profile" page. The CFPB will not use the data for any other purpose besides testing. Please do not submit any live data in the system.'
           />
         </Layout.Content>
       </Layout.Wrapper>

--- a/src/pages/Filing/PrivacyNotice.tsx
+++ b/src/pages/Filing/PrivacyNotice.tsx
@@ -15,7 +15,7 @@ function PrivacyNotice(): ReactElement {
           <TextIntroduction
             heading='Privacy Notice'
             subheading='The Consumer Financial Protection Bureau (CFPB) is collecting data to test the functionality of the Small Business Lending Data Filing Platform.'
-            description='The testing will help ensure that the system can support the filing of data needed to enforce fair lending laws pursuant to Public Law No. 111-203, Title X, Section 1071, codified at 12 C.F.R. 1002. Participation is voluntary. If you choose to participate, the CFPB will collect your first and last name to test the "Complete your user profile" page. The CFPB will not use the data for any other purpose besides testing. Please do not submit any live data in the system.'
+            description='The testing will help ensure that the system can support the submission of data needed to enforce fair lending laws pursuant to Public Law No. 111-203, Title X, Section 1071, codified at 12 C.F.R. 1002. Participation is voluntary. If you choose to participate, the CFPB will collect your first and last name to test the "Complete your user profile" page. The CFPB will not use the data for any other purpose besides testing. Please do not submit any live data in the system.'
           />
         </Layout.Content>
       </Layout.Wrapper>

--- a/src/pages/PointOfContact/index.tsx
+++ b/src/pages/PointOfContact/index.tsx
@@ -217,7 +217,7 @@ function PointOfContact(): JSX.Element {
         <FormHeaderWrapper>
           <TextIntroduction
             heading='Provide point of contact'
-            subheading="Provide the name and business contact information of a person that the Bureau or other regulators may contact with questions about your financial institution's data submission."
+            subheading="Provide the name and business contact information of a person that the Bureau or other regulators may contact with questions about your financial institution's data filing."
             description={
               <Paragraph>
                 Your financial institution&apos;s point of contact information
@@ -243,7 +243,7 @@ function PointOfContact(): JSX.Element {
           keyLogicFunc={normalKeyLogic}
         />
         <div className='mb-[1.875rem]'>
-          <SectionIntro heading='Provide contact information for your submission'>
+          <SectionIntro heading='Provide contact information for your filing'>
             You are required to complete all fields with the exception of the
             street address lines labeled optional. Your point of contact
             information will not be saved until you provide all required
@@ -255,8 +255,8 @@ function PointOfContact(): JSX.Element {
           <FieldGroup>
             <FormParagraph className='mb-[1.875rem] text-grayDarker'>
               The Consumer Financial Protection Bureau (CFPB) is collecting data
-              to test the functionality of the small business lending data
-              submission platform.{' '}
+              to test the functionality of the Small Business Lending Data
+              Filing Platform.{' '}
               <Link href='/privacy-notice'>View Privacy Notice</Link>
             </FormParagraph>
             <InputEntry

--- a/src/pages/PointOfContact/index.tsx
+++ b/src/pages/PointOfContact/index.tsx
@@ -217,7 +217,7 @@ function PointOfContact(): JSX.Element {
         <FormHeaderWrapper>
           <TextIntroduction
             heading='Provide point of contact'
-            subheading="Provide the name and business contact information of a person that the Bureau or other regulators may contact with questions about your financial institution's data filing."
+            subheading="Provide the name and business contact information of a person that the Bureau or other regulators may contact with questions about your financial institution's filing."
             description={
               <Paragraph>
                 Your financial institution&apos;s point of contact information

--- a/src/pages/ProfileForm/Step1Form/Step1FormInfoFieldGroup.tsx
+++ b/src/pages/ProfileForm/Step1Form/Step1FormInfoFieldGroup.tsx
@@ -23,8 +23,8 @@ function Step1FormInfoFieldGroup({
       <FieldGroup>
         <p className='mb-[1.875rem] text-grayDarker'>
           The Consumer Financial Protection Bureau (CFPB) is collecting data to
-          test the functionality of the small business lending data submission
-          platform. <Link href='/privacy-notice'>View Privacy Notice</Link>
+          test the functionality of the Small Business Lending Data Filing
+          Platform. <Link href='/privacy-notice'>View Privacy Notice</Link>
         </p>
         <div className='mb-[1.875rem]'>
           <InputEntry


### PR DESCRIPTION
We're making the name consistent across the website to a new name: "Small Business Lending Data Filing Platform." This also includes changing "submission" to "filing" in most contexts.

## Changes

- Small Business Lending Data Submission Platform -> Small Business Lending Filing Platform
  - index.html for title and meta info
  - App.tsx
  - BetaAndLegalNoice.tsx
  - Privacy notice
  - Point of contact
  - Complete user profile
- Submission to Filing
  - FormErrorHeader in point of contact form validation
  - Review institution info
  - Sign and Submit
  - Post submission page (not implemented)
  - Filing Home
  - Point of contact
- "platform" to "beta platform" when referring directly to the beta in the beta/legal notice
- Remove "submission" from the report name and change hyphens to underscores

## How to test this PR

Currently on the dev environment for review

1. Has the copy changed?
2. Does the site still work?
