### PR TITLE
[Bug] InstitutionHeading Pipe Spacing Fix

### DIFF
--- a/src/pages/Filing/FilingApp/InstitutionHeading.tsx
+++ b/src/pages/Filing/FilingApp/InstitutionHeading.tsx
@@ -17,7 +17,9 @@ function InstitutionHeading({
       content.push(item);
     }
   }
-  const contentUsed = content.filter(Boolean).join(`${'  '}|${'  '}`);
+  const contentUsed = content
+    .filter(Boolean)
+    .join(`${'\u00A0\u00A0'}|${'\u00A0\u00A0'}`);
   return <Heading type={headingType}>{contentUsed}</Heading>;
 }
 export default InstitutionHeading;


### PR DESCRIPTION
Fixed a bug that was causing one space to appear instead of the intended two.

## Changes

- src
  - pages
    - Filing
      - FilingApp
        - InsitutionHeading.tsx: Replaced double spaces with double unicode non-breaking spaces.

## How to test this PR

1. Pull the branch
2. Relaunch whatever is necessary
3. Navigate to a page in the app that contains the Filing Steps and the Institution Heading
4. Verify that the pipe character is surrounded by two spaces in the Institution Heading. The attached screenshot has a red box which surrounds the area to check.

## Screenshots
![Screenshot 2024-10-17 at 12 27 18 PM](https://github.com/user-attachments/assets/06b50ca5-76fb-4920-849c-47e67e5b1537)