### PR TITLE
feat: [InstitutionHeading] Support rendering as a link (isProfileLink) to the institution profile

### DIFF
--- a/src/pages/Filing/FilingApp/FileSubmission.tsx
+++ b/src/pages/Filing/FilingApp/FileSubmission.tsx
@@ -279,6 +279,8 @@ export function FileSubmission(): JSX.Element {
       <WrapperPageContent className='my-[1.875rem]'>
         <InstitutionHeading
           headingType='4'
+          isProfileLink={true}
+          lei={institution?.lei}
           name={institutionName}
           filingPeriod={year}
         />

--- a/src/pages/Filing/FilingApp/FilingErrors/index.tsx
+++ b/src/pages/Filing/FilingApp/FilingErrors/index.tsx
@@ -157,6 +157,8 @@ function FilingErrors(): JSX.Element {
       <WrapperPageContent className='my-[1.875rem]'>
         <InstitutionHeading
           headingType='4'
+          isProfileLink={true}
+          lei={institution?.lei}
           name={institution?.name}
           filingPeriod={year}
         />

--- a/src/pages/Filing/FilingApp/FilingSubmit.tsx
+++ b/src/pages/Filing/FilingApp/FilingSubmit.tsx
@@ -116,6 +116,8 @@ export function FilingSubmit(): JSX.Element {
       <WrapperPageContent className='my-[1.875rem]'>
         <InstitutionHeading
           headingType='4'
+          isProfileLink={true}
+          lei={institution.lei}
           name={institution.name}
           filingPeriod={year}
         />

--- a/src/pages/Filing/FilingApp/FilingWarnings/index.tsx
+++ b/src/pages/Filing/FilingApp/FilingWarnings/index.tsx
@@ -139,6 +139,8 @@ function FilingWarnings(): JSX.Element {
       <WrapperPageContent className='my-[1.875rem]'>
         <InstitutionHeading
           headingType='4'
+          isProfileLink={true}
+          lei={institution?.lei}
           name={institution?.name}
           filingPeriod={year}
         />

--- a/src/pages/Filing/FilingApp/InstitutionHeading.tsx
+++ b/src/pages/Filing/FilingApp/InstitutionHeading.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'components/Link';
 import { Heading } from 'design-system-react';
 import type { HeadingType } from 'design-system-react/dist/components/Headings/Heading';
 import type { InstitutionDataType } from './InstitutionCard.types';
@@ -8,18 +9,27 @@ function InstitutionHeading({
   lei,
   filingPeriod,
   headingType = '5',
+  isProfileLink = false,
+}: InstitutionDataType & {
   // eslint-disable-next-line react/require-default-props
-}: InstitutionDataType & { headingType?: HeadingType }): JSX.Element {
-  const content: (number | string)[] = [];
+  headingType?: HeadingType;
+  // eslint-disable-next-line react/require-default-props
+  isProfileLink?: boolean;
+}): JSX.Element {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  for (const item of [name || lei, filingPeriod]) {
-    if (item) {
-      content.push(item);
-    }
-  }
-  const contentUsed = content
+  const content = [name || lei, filingPeriod]
     .filter(Boolean)
     .join(`${'\u00A0\u00A0'}|${'\u00A0\u00A0'}`);
-  return <Heading type={headingType}>{contentUsed}</Heading>;
+
+  if (isProfileLink && lei)
+    return (
+      <Heading type={headingType}>
+        <Link isRouterLink href={`/institution/${lei}`}>
+          {content}
+        </Link>
+      </Heading>
+    );
+
+  return <Heading type={headingType}>{content}</Heading>;
 }
 export default InstitutionHeading;

--- a/src/pages/PointOfContact/index.tsx
+++ b/src/pages/PointOfContact/index.tsx
@@ -209,6 +209,8 @@ function PointOfContact(): JSX.Element {
       <WrapperPageContent className='my-[1.875rem]'>
         <InstitutionHeading
           headingType='4'
+          isProfileLink
+          lei={institution?.lei}
           name={institution?.name}
           filingPeriod={year}
         />


### PR DESCRIPTION
Closes #1012 

## Changes

- feat: InstitutionHeading: Added prop `isProfileLink` to determine if the heading should render as a link to the Institution profile
- task: Filing app pages that use InstitutionHeading: Provide LEI so that we can link to the Institution profile

## How to test this PR

1. Run through the filing process
2. On each page of the process, confirm the Institution heading's link redirects to the Institution profile

## Screenshots
|Unvisited|Visited|
|---|---|
|<img width="1243" alt="Screenshot 2024-10-18 at 11 12 06 AM" src="https://github.com/user-attachments/assets/3da81309-ccec-4a02-a010-6b428035e921">|<img width="1235" alt="Screenshot 2024-10-18 at 11 12 17 AM" src="https://github.com/user-attachments/assets/91e5f974-2fa6-46d8-8357-d587c91cf42d">|

