### PR TITLE
fix(e2e): account for phone extension changes

### DIFF
--- a/e2e/example.spec.demo.ts
+++ b/e2e/example.spec.demo.ts
@@ -86,7 +86,7 @@ test('proof of concept', async ({ page }) => {
         .getByLabel('Phone numberPhone number')
         .fill(pointOfContactJson.phone_number);
       await page
-        .getByLabel('Extension (optional)Extension')
+        .getByLabel('Phone extension (optional)')
         .fill(pointOfContactJson.phone_ext);
       await page
         .getByLabel('Email addressEmail address')

--- a/e2e/fixtures/testFixture.ts
+++ b/e2e/fixtures/testFixture.ts
@@ -337,7 +337,7 @@ export const test = baseTest.extend<{
           .getByLabel('Phone numberPhone number')
           .fill(pointOfContactJson.phone_number);
         await page
-          .getByLabel('Extension (optional)Extension')
+          .getByLabel('Phone Extension (optional)')
           .fill(pointOfContactJson.phone_ext);
         await page
           .getByLabel('Email addressEmail address')

--- a/e2e/pages/filing-app/formAlerts.spec.ts
+++ b/e2e/pages/filing-app/formAlerts.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '@playwright/test';
 import { test } from '../../fixtures/testFixture';
+import pointOfContactJson from '../../test-data/point-of-contact/point-of-contact-data-1.json';
 import { ResultUploadMessage, uploadFile } from '../../utils/uploadFile';
 
 test('Form Alerts', async ({
@@ -247,7 +248,7 @@ test('Form Alerts', async ({
         page.locator('.m-notification__error'),
         'Error alert is visible',
       ).toContainText(
-        'There was a problem updating your point of contact informationEnter the first name of the point of contactEnter the last name of the point of contactEnter the phone number of the point of contactEnter the email address of the point of contactEnter the street address of the point of contactEnter the city of the point of contactSelect the state or territory of the point of contactEnter the ZIP code of the point of contact',
+        'There was a problem updating your point of contact informationEnter the first name of the point of contactEnter the last name of the point of contactEnter the phone number of the point of contactEnter a valid phone extensionEnter the email address of the point of contactEnter the street address of the point of contactEnter the city of the point of contactSelect the state or territory of the point of contactEnter the ZIP code of the point of contact',
       );
     });
 
@@ -257,6 +258,9 @@ test('Form Alerts', async ({
         await page.getByLabel('First name').fill('Playwright');
         await page.getByLabel('Last name').fill('Test');
         await page.getByLabel('Phone number').fill('555-555-5555');
+        await page
+          .getByLabel('Phone extension (optional)')
+          .fill(pointOfContactJson.phone_ext);
         await page.getByLabel('Email address').fill('playwright@test.com');
         await page.getByLabel('Street address line 1').fill('555 Main St.');
         await page.getByLabel('City').fill('Utah (U');


### PR DESCRIPTION
Was looking at [this PR](https://github.com/cfpb/sbl-frontend/pull/988) and noticed some test failures. Fixes some e2e test failures that arose from the recent phone extension v2 changes.

## Changes

- changes extension -> phone extension
- updates error text

## How to test this PR

1. Tests are now passing, check out the screenshots.

## Screenshots
**Before**
<img width="1392" alt="Screenshot 2024-10-22 at 9 32 07 AM" src="https://github.com/user-attachments/assets/8e94f806-5fb2-4241-b622-c09ada309759">

**After**
<img width="1392" alt="Screenshot 2024-10-22 at 10 17 42 AM" src="https://github.com/user-attachments/assets/a778a396-a0d0-4ceb-badc-52bd2d235f7c">


## Notes

- Lots could be done to import some of these expected strings, but this should fix our issues for now.
