### PR TITLE
[e2e] Investigate performance issues

### DIFF
--- a/e2e/example.spec.demo.ts
+++ b/e2e/example.spec.demo.ts
@@ -4,11 +4,9 @@ import { expect } from '@playwright/test';
 import { test } from './fixtures/testFixture';
 import pointOfContactJson from './test-data/point-of-contact/point-of-contact-data-1.json';
 import { ResultUploadMessage, uploadFile } from './utils/uploadFile';
+import { clickContinue } from './utils/navigation.utils';
 
 test('proof of concept', async ({ page }) => {
-  test.slow();
-  const minorDelay = 500;
-
   await test.step('Unauthenticated homepage: navigate to Authenticated homepage', async () => {
     await page.goto('/');
     await expect(page.locator('h1')).toContainText(
@@ -55,9 +53,7 @@ test('proof of concept', async ({ page }) => {
     });
 
     await test.step('Upload file: navigate to Resolve errors (syntax) with no errors after upload', async () => {
-      await page.waitForSelector('#nav-next');
-      await page.waitForTimeout(minorDelay);
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await clickContinue(test, page);
       await expect(page.locator('h1')).toContainText('Resolve errors (syntax)');
     });
 

--- a/e2e/fixtures/testFixture.ts
+++ b/e2e/fixtures/testFixture.ts
@@ -1,4 +1,11 @@
-import type { Page } from '@playwright/test';
+import type {
+  Page,
+  PlaywrightTestArgs,
+  PlaywrightTestOptions,
+  PlaywrightWorkerArgs,
+  PlaywrightWorkerOptions,
+  TestType,
+} from '@playwright/test';
 import { test as baseTest, expect } from '@playwright/test';
 import pointOfContactJson from '../test-data/point-of-contact/point-of-contact-data-1.json';
 import createDomainAssociation from '../utils/createDomainAssociation';
@@ -12,6 +19,26 @@ import {
   getTestDataObject,
 } from '../utils/testFixture.utils';
 import { ResultUploadMessage, uploadFile } from '../utils/uploadFile';
+import { clickContinue, clickContinueNext } from '../utils/navigation.utils';
+
+export type SBLPlaywrightTest = TestType<
+  PlaywrightTestArgs &
+    PlaywrightTestOptions & {
+      isNonAssociatedUser: boolean; // Skips creating a domain association and creating a financial institution
+      account: Account;
+      authHook: void;
+      navigateToAuthenticatedHomePage: Page;
+      navigateToFilingHome: Page;
+      navigateToProvideTypeOfFinancialInstitution: Page;
+      navigateToUploadFile: Page;
+      navigateToReviewWarningsAfterOnlyWarningsUpload: Page;
+      navigateToSyntaxErrorsAfterSyntaxErrorsUpload: Page;
+      navigateToLogicErrorsAfterLogicErrorsUpload: Page;
+      navigateToProvidePointOfContact: Page;
+      navigateToSignAndSubmit: Page;
+    },
+  PlaywrightWorkerArgs & PlaywrightWorkerOptions
+>;
 
 export const test = baseTest.extend<{
   isNonAssociatedUser: boolean; // Skips creating a domain association and creating a financial institution
@@ -100,7 +127,6 @@ export const test = baseTest.extend<{
         await page.getByRole('button', { name: 'Sign In' }).click();
         await expect(page.locator('h1')).toContainText(
           'Complete your user profile',
-          { timeout: 30_000 },
         );
 
         // Two versions of Complete User Profile - with and without associations
@@ -183,11 +209,8 @@ export const test = baseTest.extend<{
         exact: true,
       });
       await page.getByText('Bank or savings association').click();
-      await page.getByRole('button', { name: 'Continue' }).click();
-
-      await expect(page.locator('h1')).toContainText('Upload file', {
-        timeout: 30_000,
-      });
+      await clickContinue(test, page);
+      await expect(page.locator('h1')).toContainText('Upload file');
       await use(page);
     });
   },
@@ -210,11 +233,7 @@ export const test = baseTest.extend<{
       });
 
       await test.step('Upload file: navigate to Resolve errors (syntax) with no errors after upload', async () => {
-        await page.waitForSelector('#nav-next');
-        await page.waitForTimeout(500);
-        await page
-          .getByRole('button', { name: 'Continue to next step' })
-          .click();
+        await clickContinueNext(test, page);
         await expect(page.locator('h1')).toContainText(
           'Resolve errors (syntax)',
         );
@@ -242,18 +261,14 @@ export const test = baseTest.extend<{
       });
 
       await test.step('Upload file: navigate to Resolve errors (syntax) with no errors after upload', async () => {
-        await page.waitForSelector('#nav-next');
-        await page.waitForTimeout(500);
-        await page
-          .getByRole('button', { name: 'Continue to next step' })
-          .click();
+        await clickContinueNext(test, page);
         await expect(page.locator('h1')).toContainText(
           'Resolve errors (syntax)',
         );
       });
 
       await test.step('Resolve errors (logic): navigate to Resolve errors (logic) with errors after upload', async () => {
-        await page.getByRole('button', { name: 'Continue' }).click();
+        await clickContinue(test, page);
         await expect(page.locator('h1')).toContainText(
           'Resolve errors (logic)',
         );
@@ -281,27 +296,21 @@ export const test = baseTest.extend<{
       });
 
       await test.step('Upload file: navigate to Resolve errors (syntax) with no errors after upload', async () => {
-        await page.waitForSelector('#nav-next');
-        await page.waitForTimeout(500);
-        await page
-          .getByRole('button', { name: 'Continue to next step' })
-          .click();
+        await clickContinueNext(test, page);
         await expect(page.locator('h1')).toContainText(
           'Resolve errors (syntax)',
         );
       });
 
       await test.step('Resolve errors (syntax): navigate to Resolve errors (logic) with no errors after upload', async () => {
-        await page.getByRole('button', { name: 'Continue' }).click();
+        await clickContinue(test, page);
         await expect(page.locator('h1')).toContainText(
           'Resolve errors (logic)',
         );
       });
 
       await test.step('Resolve errors (logic): navigate to Review warnings', async () => {
-        await page
-          .getByRole('button', { name: 'Continue to next step' })
-          .click();
+        await clickContinueNext(test, page);
         await expect(page.locator('h1')).toContainText('Review warnings');
       });
       await use(page);
@@ -315,10 +324,9 @@ export const test = baseTest.extend<{
     navigateToReviewWarningsAfterOnlyWarningsUpload;
     await test.step('Review warnings: navigate to Provide point of contact', async () => {
       await page.getByText('I verify the accuracy of').click();
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
+      await clickContinueNext(test, page);
       await expect(page.locator('h1')).toContainText(
         'Provide point of contact',
-        { timeout: 30_000 },
       );
     });
     await use(page);
@@ -363,9 +371,7 @@ export const test = baseTest.extend<{
           .fill(pointOfContactJson.hq_address_zip);
       });
       await test.step('Provide point of contact: continue to next step', async () => {
-        await page
-          .getByRole('button', { name: 'Continue to next step' })
-          .click();
+        await clickContinueNext(test, page);
         await expect(page.locator('h1')).toContainText('Sign and submit');
       });
     });

--- a/e2e/pages/filing-app/complete-user-profile/checkCupFormErrors.spec.ts
+++ b/e2e/pages/filing-app/complete-user-profile/checkCupFormErrors.spec.ts
@@ -7,15 +7,11 @@ import { controlUnicode } from '../../../utils/unicodeConstants';
 test('Complete the User Profile: Checking for form errors based on user input', async ({
   page,
 }) => {
-  test.slow();
-
   await test.step('Complete the User Profile: Check that the error header render when no input is filled', async () => {
     await page.getByLabel('Submit User Profile').click();
-    await expect(page.locator('#step1FormErrorHeader div').first()).toBeVisible(
-      {
-        timeout: 30_000,
-      },
-    );
+    await expect(
+      page.locator('#step1FormErrorHeader div').first(),
+    ).toBeVisible();
   });
 
   await test.step('Complete the User Profile: Check the first and last names for invalid input', async () => {
@@ -40,15 +36,11 @@ test('Complete the User Profile: Checking for form errors based on user input', 
 test('Complete the User Profile: Checking for input length restriction', async ({
   page,
 }) => {
-  test.slow();
-
   await test.step('Complete the User Profile: Check that the error header render when no input is filled', async () => {
     await page.getByLabel('Submit User Profile').click();
-    await expect(page.locator('#step1FormErrorHeader div').first()).toBeVisible(
-      {
-        timeout: 30_000,
-      },
-    );
+    await expect(
+      page.locator('#step1FormErrorHeader div').first(),
+    ).toBeVisible();
   });
 
   await test.step('Complete the User Profile: Check the first and last names for invalid input', async () => {

--- a/e2e/pages/filing-app/filing-step-routing/_shared.ts
+++ b/e2e/pages/filing-app/filing-step-routing/_shared.ts
@@ -32,7 +32,7 @@ export const verifyRedirects = async ({
   for (const futureStep of userShouldNotAccess) {
     await test.step(`${testLabel}: Verify user cannot access ${futureStep}`, async () => {
       await page.goto(baseURL + futureStep);
-      await expect(page).toHaveURL(afterRedirectURL, { timeout: 10_000 });
+      await expect(page).toHaveURL(afterRedirectURL);
       await expect(page.locator('h1')).toContainText(afterRedirectHeading);
     });
   }

--- a/e2e/pages/filing-app/filing-step-routing/errorsLogic.spec.ts
+++ b/e2e/pages/filing-app/filing-step-routing/errorsLogic.spec.ts
@@ -13,8 +13,6 @@ const afterRedirectURL = /.*errors\/errors-syntax$/;
 test(
   testLabel,
   async ({ page, navigateToLogicErrorsAfterLogicErrorsUpload }) => {
-    test.slow();
-
     navigateToLogicErrorsAfterLogicErrorsUpload;
 
     await verifyRedirects({

--- a/e2e/pages/filing-app/filing-step-routing/errorsSyntax.spec.ts
+++ b/e2e/pages/filing-app/filing-step-routing/errorsSyntax.spec.ts
@@ -18,8 +18,6 @@ const afterRedirectURL = /.*errors\/errors-syntax$/;
 test(
   testLabel,
   async ({ page, navigateToSyntaxErrorsAfterSyntaxErrorsUpload }) => {
-    test.slow();
-
     navigateToSyntaxErrorsAfterSyntaxErrorsUpload;
 
     await verifyRedirects({

--- a/e2e/pages/filing-app/filing-step-routing/noUpload.spec.ts
+++ b/e2e/pages/filing-app/filing-step-routing/noUpload.spec.ts
@@ -11,8 +11,6 @@ const afterRedirectHeading = 'Upload file';
 const afterRedirectURL = /.*\/upload$/;
 
 test(testLabel, async ({ page, navigateToUploadFile }) => {
-  test.slow();
-
   navigateToUploadFile;
 
   await verifyRedirects({

--- a/e2e/pages/filing-app/filing-step-routing/pointOfContact.spec.ts
+++ b/e2e/pages/filing-app/filing-step-routing/pointOfContact.spec.ts
@@ -11,8 +11,6 @@ const afterRedirectHeading = 'Provide point of contact';
 const afterRedirectURL = /.*\/contact$/;
 
 test(testLabel, async ({ page, navigateToProvidePointOfContact }) => {
-  test.slow();
-
   navigateToProvidePointOfContact;
 
   await verifyRedirects({

--- a/e2e/pages/filing-app/filing-step-routing/warnings.spec.ts
+++ b/e2e/pages/filing-app/filing-step-routing/warnings.spec.ts
@@ -13,8 +13,6 @@ const afterRedirectURL = /.*\/warnings$/;
 test(
   testLabel,
   async ({ page, navigateToReviewWarningsAfterOnlyWarningsUpload }) => {
-    test.slow();
-
     navigateToReviewWarningsAfterOnlyWarningsUpload;
 
     await verifyRedirects({

--- a/e2e/pages/filing-app/formAlerts.spec.ts
+++ b/e2e/pages/filing-app/formAlerts.spec.ts
@@ -2,13 +2,12 @@ import { expect } from '@playwright/test';
 import { test } from '../../fixtures/testFixture';
 import pointOfContactJson from '../../test-data/point-of-contact/point-of-contact-data-1.json';
 import { ResultUploadMessage, uploadFile } from '../../utils/uploadFile';
+import { clickContinue, clickContinueNext } from '../../utils/navigation.utils';
 
 test('Form Alerts', async ({
   page,
   navigateToProvideTypeOfFinancialInstitution,
 }) => {
-  test.slow();
-
   // Type of financial institution page
   await test.step('Type of financial institution page', async () => {
     navigateToProvideTypeOfFinancialInstitution;
@@ -18,13 +17,9 @@ test('Form Alerts', async ({
 
     // Submit Incomplete form
     await test.step('Submit Incomplete form', async () => {
-      await test.step('Click: Continue', async () => {
-        await page.getByRole('button', { name: 'Continue' }).click();
-      });
+      await clickContinue(test, page);
       await test.step('Error Alert is visible', async () => {
-        await page.waitForSelector('#TypesFinancialInstitutionsErrors', {
-          timeout: 10_000,
-        });
+        await page.waitForSelector('#TypesFinancialInstitutionsErrors');
         await expect(
           page.locator(
             '#TypesFinancialInstitutionsErrors div.m-notification_content',
@@ -41,9 +36,7 @@ test('Form Alerts', async ({
       await test.step('Complete form', async () => {
         await page.getByText('Bank or savings association').check();
       });
-      await test.step('Click: Continue', async () => {
-        await page.getByRole('button', { name: 'Continue' }).click();
-      });
+      await clickContinue(test, page);
     });
   });
 
@@ -60,11 +53,7 @@ test('Form Alerts', async ({
     });
 
     // Continue to next page
-    await test.step('Click: Continue', async () => {
-      await page.waitForSelector('#nav-next');
-      await page.waitForTimeout(500);
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
-    });
+    await clickContinueNext(test, page);
   });
 
   // Resolve errors (syntax) page
@@ -78,12 +67,7 @@ test('Form Alerts', async ({
     ).toContainText(
       'Your register contains syntax errorsThere may be an issue with the data type or format of one or more values in your file. Make sure your register meets the requirements detailed in the filing instructions guide (section 4, "Data validation"), make the corrections, and upload a new file.',
     );
-    await test.step('Click: Continue', async () => {
-      await page
-        .getByRole('button', { name: 'Continue' })
-        .click({ timeout: 500 });
-    });
-
+    await clickContinue(test, page);
     await expect(
       page.locator('#error-footer-alert'),
       'Footer alert is visible',
@@ -108,11 +92,7 @@ test('Form Alerts', async ({
     });
 
     // Continue to next page
-    await test.step('Click: Continue', async () => {
-      await page.waitForSelector('#nav-next');
-      await page.waitForTimeout(500);
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
-    });
+    await clickContinueNext(test, page);
   });
 
   // Resolve errors (syntax) page
@@ -124,9 +104,7 @@ test('Form Alerts', async ({
       page.locator('.m-notification__success'),
       'Success message is visible',
     ).toContainText('Your register contains no syntax errors');
-    await test.step('Click: Continue', async () => {
-      await page.getByRole('button', { name: 'Continue' }).click();
-    });
+    await clickContinue(test, page);
   });
 
   // Resolve errors (logic) page
@@ -140,12 +118,7 @@ test('Form Alerts', async ({
     ).toContainText(
       'Your register contains logic errorsThere is missing data, incorrect data, or conflicting information in your file. Make sure your register meets the requirements detailed in the filing instructions guide (section 4, "Data validation"), make the corrections, and upload a new file.',
     );
-    await test.step('Click: Continue', async () => {
-      await page
-        .getByRole('button', { name: 'Continue to next step' })
-        .click({ timeout: 500 });
-    });
-
+    await clickContinueNext(test, page);
     await expect(
       page.locator('#error-footer-alert'),
       'Footer alert is visible',
@@ -168,12 +141,7 @@ test('Form Alerts', async ({
       filePath: '../test-data/sample-sblar-files/logic-warnings_small.csv',
       resultMessage: ResultUploadMessage.warning,
     });
-
-    await test.step('Click: Continue', async () => {
-      await page
-        .getByRole('button', { name: 'Continue to next step' })
-        .click({ timeout: 30_000 });
-    });
+    await clickContinueNext(test, page);
   });
 
   // Resolve errors (syntax) page
@@ -185,12 +153,7 @@ test('Form Alerts', async ({
       page.locator('.m-notification__success'),
       'Success message is visible',
     ).toContainText('Your register contains no syntax errors');
-
-    await test.step('Click: Continue', async () => {
-      await page
-        .getByRole('button', { name: 'Continue' })
-        .click({ timeout: 30_000 });
-    });
+    await clickContinue(test, page);
   });
 
   // Resolve errors (logic) page
@@ -202,11 +165,7 @@ test('Form Alerts', async ({
       page.locator('.m-notification__success'),
       'Success message is visible',
     ).toContainText('Your register contains no logic errors');
-    await test.step('Click: Continue', async () => {
-      await page
-        .getByRole('button', { name: 'Continue to next step' })
-        .click({ timeout: 30_000 });
-    });
+    await clickContinueNext(test, page);
   });
 
   // Review warnings page
@@ -214,9 +173,7 @@ test('Form Alerts', async ({
     await expect(page.locator('h1'), 'h1 is correct').toContainText(
       'Review warnings',
     );
-    await test.step('Click: Continue', async () => {
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
-    });
+    await clickContinueNext(test, page);
     await expect(
       page.locator('#error-header-alert'),
       'Error alert is visible',
@@ -224,11 +181,9 @@ test('Form Alerts', async ({
       'You must correct or verify the accuracy of register values to continue to the next step.',
     );
     await test.step('Click: Verify checkbox', async () => {
-      await page.getByText('I verify the accuracy of').check({ timeout: 500 });
+      await page.getByText('I verify the accuracy of').check();
     });
-    await test.step('Click: Continue', async () => {
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
-    });
+    await clickContinueNext(test, page);
   });
 
   // Point of contact page
@@ -239,11 +194,7 @@ test('Form Alerts', async ({
 
     // Submit Incomplete form
     await test.step('Submit Incomplete form', async () => {
-      await test.step('Click: Continue', async () => {
-        await page
-          .getByRole('button', { name: 'Continue to next step' })
-          .click();
-      });
+      await clickContinueNext(test, page);
       await expect(
         page.locator('.m-notification__error'),
         'Error alert is visible',
@@ -268,9 +219,9 @@ test('Form Alerts', async ({
         await page.getByLabel('Zip code').fill('55555');
       });
     });
-    await test.step('Click: Continue', async () => {
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
-    });
+
+    // Continue to Sign and Submit
+    await clickContinueNext(test, page);
   });
 
   // Sign and submit page

--- a/e2e/pages/filing-app/point-of-contact/checkPocFormErrors.spec.ts
+++ b/e2e/pages/filing-app/point-of-contact/checkPocFormErrors.spec.ts
@@ -11,29 +11,28 @@ import {
   EmailInputCharLimit,
   ZipInputCharLimit,
 } from 'utils/constants';
+import { clickContinueNext } from '../../../utils/navigation.utils';
 
 test('Point of Contact: Checking for form errors based on user input', async ({
   page,
   navigateToProvidePointOfContact,
 }) => {
-  test.slow();
-
   navigateToProvidePointOfContact;
 
   await test.step('Point of Contact: Check that the error header render when no input is filled', async () => {
-    await page.getByRole('button', { name: 'Continue to next step' }).click();
+    await clickContinueNext(test, page);
     await expect(
       page.locator('#PointOfContactFormErrors div').first(),
     ).toBeVisible();
   });
 
   await test.step('Point of Contact: Check the first and last names for invalid input', async () => {
-    await page.getByRole('button', { name: 'Continue to next step' }).click();
+    await clickContinueNext(test, page);
     await page.getByLabel('First name').click();
     await page.getByLabel('First name').fill('$!@#%^&*()');
     await page.getByLabel('Last name').click();
     await page.getByLabel('Last name').fill('$!@#%^&*()');
-    await page.getByRole('button', { name: 'Continue to next step' }).click();
+    await clickContinueNext(test, page);
     await expect(page.locator('form')).toContainText(
       'The first name must not contain invalid characters',
     );
@@ -53,12 +52,10 @@ test('Point of Contact: Checking for unicode tolerance based on user input', asy
   page,
   navigateToProvidePointOfContact,
 }) => {
-  test.slow();
-
   navigateToProvidePointOfContact;
 
   await test.step('Point of Contact: Check that the error header render when no input is filled', async () => {
-    await page.getByRole('button', { name: 'Continue to next step' }).click();
+    await clickContinueNext(test, page);
     await expect(
       page.locator('#PointOfContactFormErrors div').first(),
     ).toBeVisible();
@@ -155,7 +152,7 @@ test('Point of Contact: Checking for unicode tolerance based on user input', asy
       unexpected: unexpectedValues.zipField,
     });
 
-    await page.getByRole('button', { name: 'Continue to next step' }).click();
+    await clickContinueNext(test, page);
 
     await expect(page.locator('#PointOfContactFormErrors')).toContainText(
       'Enter a valid phone number',

--- a/e2e/pages/filing-app/sign-and-submit/completeFilingFlowWithOnlyWarnings.spec.ts
+++ b/e2e/pages/filing-app/sign-and-submit/completeFilingFlowWithOnlyWarnings.spec.ts
@@ -5,8 +5,6 @@ test('Sign and submit: complete filing flow with only warnings', async ({
   page,
   navigateToSignAndSubmit,
 }) => {
-  test.slow();
-
   navigateToSignAndSubmit;
 
   await test.step('Sign and submit: verify completion', async () => {

--- a/e2e/pages/filing-app/unavailableApis.spec.ts
+++ b/e2e/pages/filing-app/unavailableApis.spec.ts
@@ -1,15 +1,13 @@
 import { expect } from '@playwright/test';
 import { test } from '../../fixtures/testFixture';
 import { blockApi, verifyApiBlockThenUnblock } from '../../utils/blockApi';
-import { TIMEOUT_LG, TIMEOUT_XS } from '../../utils/timeoutConstants';
 import { ResultUploadMessage, uploadFile } from '../../utils/uploadFile';
+import { clickContinue, clickContinueNext } from '../../utils/navigation.utils';
 
 test('Blocking API Calls - Error Boundaries', async ({
   page,
   navigateToProvideTypeOfFinancialInstitution,
 }) => {
-  test.slow();
-
   // Type of Financial Institution page
   await test.step('Type of Financial Institution page', async () => {
     navigateToProvideTypeOfFinancialInstitution;
@@ -24,7 +22,7 @@ test('Blocking API Calls - Error Boundaries', async ({
     // Complete Form and Continue
     await test.step('Complete Form', async () => {
       await page.getByText('Bank or savings association').check();
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await clickContinue(test, page);
     });
   });
 
@@ -49,11 +47,7 @@ test('Blocking API Calls - Error Boundaries', async ({
     });
 
     // Continue to next page
-    await test.step('Click: Continue', async () => {
-      await page.waitForSelector('#nav-next');
-      await page.waitForTimeout(TIMEOUT_XS);
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
-    });
+    await clickContinueNext(test, page);
   });
 
   // Resolve errors page
@@ -66,23 +60,18 @@ test('Blocking API Calls - Error Boundaries', async ({
     });
 
     // Navigate: Resolve errors (logic)
-    await test.step('Click: Continue', async () => {
-      await page.getByRole('button', { name: 'Continue' }).click();
+    await test.step('Resolve errors (logic) page', async () => {
+      await clickContinue(test, page);
       await expect(page.locator('h1'), 'h1 is correct').toContainText(
         'Resolve errors (logic)',
       );
     });
-
-    await test.step('Click Continue', async () => {
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
-    });
+    await clickContinueNext(test, page);
   });
 
   // Review warnings page
   await test.step('Review warnings page', async () => {
-    await expect(page.locator('h1')).toContainText('Review warnings', {
-      timeout: TIMEOUT_LG,
-    });
+    await expect(page.locator('h1')).toContainText('Review warnings');
 
     // Block API Call: **/v1/institutions/
     await test.step('Block API: /v1/institutions', async () => {
@@ -91,16 +80,12 @@ test('Blocking API Calls - Error Boundaries', async ({
 
     // Confirm Error Alert
     await test.step('Error Alert is visible', async () => {
-      test.setTimeout(150_000);
       await test.step('Refresh page', async () => {
         await page.reload();
       });
 
       await expect(page.locator('h1'), 'h1 is visible').toContainText(
         'Review warnings',
-        {
-          timeout: TIMEOUT_LG,
-        },
       );
       await expect(
         page.locator('#main .m-notification__error'),
@@ -118,8 +103,8 @@ test('Blocking API Calls - Error Boundaries', async ({
     });
 
     await test.step('Click: Continue', async () => {
-      await page.getByText('I verify the accuracy of').check({ timeout: 500 });
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
+      await page.getByText('I verify the accuracy of').check();
+      await clickContinueNext(test, page);
     });
   });
 

--- a/e2e/pages/filing-app/uploadFile/completeUploadLogicErrors.spec.ts
+++ b/e2e/pages/filing-app/uploadFile/completeUploadLogicErrors.spec.ts
@@ -2,10 +2,12 @@ import { expect } from '@playwright/test';
 import { test } from '../../../fixtures/testFixture';
 import { ResultUploadMessage, uploadFile } from '../../../utils/uploadFile';
 import { verifyDownloadableReport } from '../../../utils/verifyDownloadableReport';
+import {
+  clickContinue,
+  clickContinueNext,
+} from '../../../utils/navigation.utils';
 
 test('Resolve Errors (Logic)', async ({ page, navigateToUploadFile }) => {
-  test.slow();
-
   navigateToUploadFile;
 
   await test.step('Upload file: navigate to Resolve Errors (Logic) after upload', async () => {
@@ -21,23 +23,16 @@ test('Resolve Errors (Logic)', async ({ page, navigateToUploadFile }) => {
     });
 
     await test.step('Verify Resolve Errors (syntax) and zero errors', async () => {
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
-      await expect(page.locator('h1')).toContainText(
-        'Resolve errors (syntax)',
-        {
-          timeout: 30_000,
-        },
-      );
+      await clickContinueNext(test, page);
+      await expect(page.locator('h1')).toContainText('Resolve errors (syntax)');
       await expect(
         page.getByText('Your register contains no syntax errors'),
-      ).toBeVisible({ timeout: 40_000 });
+      ).toBeVisible();
     });
 
     await test.step('Verify Resolve Errors (logic) and number of errors', async () => {
-      await page.getByRole('button', { name: 'Continue' }).click();
-      await expect(page.locator('h1')).toContainText('Resolve errors (logic)', {
-        timeout: 30_000,
-      });
+      await clickContinue(test, page);
+      await expect(page.locator('h1')).toContainText('Resolve errors (logic)');
       await expect(page.locator('#error-header-alert')).toContainText(
         'Your register contains logic errors',
       );
@@ -53,7 +48,8 @@ test('Resolve Errors (Logic)', async ({ page, navigateToUploadFile }) => {
     });
 
     await test.step('Verify navigation of paginated (logic) content', async () => {
-      await page.getByRole('button', { name: 'Continue' }).click();
+      await clickContinue(test, page);
+
       const section = page
         .locator('#multi-field-errors div')
         .filter({ hasText: 'E2004' })

--- a/e2e/pages/filing-app/uploadFile/completeUploadSyntaxErrors.spec.ts
+++ b/e2e/pages/filing-app/uploadFile/completeUploadSyntaxErrors.spec.ts
@@ -2,10 +2,9 @@ import { expect } from '@playwright/test';
 import { test } from '../../../fixtures/testFixture';
 import { ResultUploadMessage, uploadFile } from '../../../utils/uploadFile';
 import { verifyDownloadableReport } from '../../../utils/verifyDownloadableReport';
+import { clickContinueNext } from '../../../utils/navigation.utils';
 
 test('Resolve Errors (Syntax)', async ({ page, navigateToUploadFile }) => {
-  test.slow();
-
   navigateToUploadFile;
 
   await test.step('Upload file: navigate to Resolve Errors (syntax) after upload', async () => {
@@ -20,21 +19,11 @@ test('Resolve Errors (Syntax)', async ({ page, navigateToUploadFile }) => {
     });
 
     await test.step('Verify Resolve Errors (syntax) and number of errors', async () => {
-      await page.getByRole('button', { name: 'Continue to next step' }).click();
-      await expect(page.locator('h1')).toContainText(
-        'Resolve errors (syntax)',
-        {
-          timeout: 30_000,
-        },
-      );
-      await expect(page.locator('#error-header-alert')).toBeVisible({
-        timeout: 30_000,
-      });
+      await clickContinueNext(test, page);
+      await expect(page.locator('h1')).toContainText('Resolve errors (syntax)');
+      await expect(page.locator('#error-header-alert')).toBeVisible();
       await expect(page.locator('h2')).toContainText(
         'Single-field errors: 136 found',
-        {
-          timeout: 20_000,
-        },
       );
     });
 

--- a/e2e/pages/shared-lending-platform/InstitutionProfile.spec.ts
+++ b/e2e/pages/shared-lending-platform/InstitutionProfile.spec.ts
@@ -6,8 +6,6 @@ test('Institution Profile Page', async ({
   context,
   navigateToFilingHome,
 }) => {
-  test.slow();
-
   // Go to Profile page
   await test.step('User Profile Page', async () => {
     navigateToFilingHome;

--- a/e2e/pages/shared-lending-platform/Navigation.spec.ts
+++ b/e2e/pages/shared-lending-platform/Navigation.spec.ts
@@ -2,8 +2,6 @@ import { expect } from '@playwright/test';
 import { test } from '../../fixtures/testFixture';
 
 test('Navigation', async ({ page, navigateToFilingHome }) => {
-  test.slow();
-
   navigateToFilingHome;
 
   await test.step('Main Navigation', async () => {

--- a/e2e/pages/shared-lending-platform/NonAssociatedUserProfile.spec.ts
+++ b/e2e/pages/shared-lending-platform/NonAssociatedUserProfile.spec.ts
@@ -12,8 +12,6 @@ test.use({ isNonAssociatedUser: true });
 test('Complete User Profile -- No Associations -- process', async ({
   page,
 }) => {
-  test.slow();
-
   await test.step('Fillout Complete User Profile (No Associations) and verify 24-48 hour summary message', async () => {
     await page.getByLabel('First name').click();
     await page.getByLabel('First name').fill('exampleFirstName');
@@ -38,8 +36,6 @@ test('Complete User Profile -- No Associations -- process', async ({
 test('Complete User Profile with Bad Unicode -- No Associations -- process', async ({
   page,
 }) => {
-  test.slow();
-
   await test.step('Fillout Complete User Profile (No Associations) with bad unicode and verify values', async () => {
     const expectedValues = {
       firstField: controlUnicode.slice(0, DefaultInputCharLimit),

--- a/e2e/pages/shared-lending-platform/UpdateInstitutionProfile.spec.ts
+++ b/e2e/pages/shared-lending-platform/UpdateInstitutionProfile.spec.ts
@@ -8,8 +8,6 @@ test('Update Institution Profile Page', async ({
   page,
   navigateToFilingHome,
 }) => {
-  test.slow();
-
   // Profile page
   await test.step('User Profile Page', async () => {
     navigateToFilingHome;
@@ -199,8 +197,6 @@ test('Update Institution Profile Page: Check Character Limits', async ({
   page,
   navigateToFilingHome,
 }) => {
-  test.slow();
-
   // Profile page
   await test.step('User Profile Page', async () => {
     navigateToFilingHome;

--- a/e2e/pages/shared-lending-platform/UserProfile.spec.ts
+++ b/e2e/pages/shared-lending-platform/UserProfile.spec.ts
@@ -2,8 +2,6 @@ import { expect } from '@playwright/test';
 import { test } from '../../fixtures/testFixture';
 
 test('User Profile Page', async ({ page, navigateToFilingHome }) => {
-  test.slow();
-
   // Go to Profile page
   await test.step('H1 Heading', async () => {
     navigateToFilingHome;

--- a/e2e/pages/shared-lending-platform/unauthenticated-homepage/DeniedDomain.spec.ts
+++ b/e2e/pages/shared-lending-platform/unauthenticated-homepage/DeniedDomain.spec.ts
@@ -5,8 +5,6 @@ import { webcrypto } from 'node:crypto';
 test('Unauthenticated homepage: Registering with an invalid email domain', async ({
   page,
 }) => {
-  test.slow();
-
   await test.step('Registering a new user with gmail.com email domain', async () => {
     await page.goto('/');
     await page.getByRole('button', { name: 'Sign in with Login.gov' }).click();

--- a/e2e/pages/shared-lending-platform/unauthenticated-homepage/paperworkReductionAct.spec.ts
+++ b/e2e/pages/shared-lending-platform/unauthenticated-homepage/paperworkReductionAct.spec.ts
@@ -2,8 +2,6 @@ import { expect, test } from '@playwright/test';
 import { expectedPaperworkReductionActUrl } from '../../../utils/testFixture.utils';
 
 test('Unauthenticated homepage: Paperwork Reduction Act', async ({ page }) => {
-  test.slow();
-
   await test.step('Verify on the Paperwork Reduction Act and link exists', async () => {
     await page.goto('/');
     await expect(page.locator('#sidebar')).toContainText(

--- a/e2e/pages/shared-lending-platform/unauthenticated-homepage/privacyNotice.spec.ts
+++ b/e2e/pages/shared-lending-platform/unauthenticated-homepage/privacyNotice.spec.ts
@@ -2,8 +2,6 @@ import { expect, test } from '@playwright/test';
 import { expectedPrivacyNoticeUrl } from '../../../utils/testFixture.utils';
 
 test('Unauthenticated homepage: Privacy Notice', async ({ page }) => {
-  test.slow();
-
   await test.step('Verify on the Privacy Notice overview and link exists', async () => {
     await page.goto('/');
     await expect(page.locator('#sidebar')).toContainText('Privacy Notice');

--- a/e2e/utils/blockApi.ts
+++ b/e2e/utils/blockApi.ts
@@ -1,7 +1,6 @@
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { test } from '../fixtures/testFixture';
-import { TIMEOUT_XL } from './timeoutConstants';
 
 export async function blockApi(
   page: Page,
@@ -32,7 +31,6 @@ interface VerifyApiBlockThenUnblockProperties {
   expectedHeading: string;
   page: Page;
   endpointLabel: string;
-  timeoutOverride?: number;
 }
 
 export const verifyApiBlockThenUnblock = async ({
@@ -40,13 +38,9 @@ export const verifyApiBlockThenUnblock = async ({
   expectedHeading,
   page,
   endpointLabel,
-  timeoutOverride = TIMEOUT_XL,
 }: VerifyApiBlockThenUnblockProperties) => {
-  const timeoutOption = { timeout: timeoutOverride };
-
   await expect(page.locator('h1'), 'h1 is correct').toContainText(
     expectedHeading,
-    timeoutOption,
   );
 
   // Block API Call
@@ -62,7 +56,6 @@ export const verifyApiBlockThenUnblock = async ({
 
     await expect(page.locator('h1'), 'h1 is correct').toContainText(
       'An unknown error occurred',
-      timeoutOption,
     );
   });
 
@@ -72,7 +65,6 @@ export const verifyApiBlockThenUnblock = async ({
 
     await expect(page.locator('h1'), 'h1 is correct').toContainText(
       expectedHeading,
-      timeoutOption,
     );
   });
 };

--- a/e2e/utils/navigation.utils.ts
+++ b/e2e/utils/navigation.utils.ts
@@ -1,0 +1,44 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import type { SBLPlaywrightTest } from '../fixtures/testFixture';
+
+const clickContinueHelper = async ({
+  name,
+  test,
+  page,
+  delay,
+}: {
+  name: string;
+  test: SBLPlaywrightTest;
+  page: Page;
+  delay?: boolean;
+}) => {
+  await test.step(`Click: ${name}`, async () => {
+    await expect(page.getByRole('button', { name })).toBeVisible();
+    if (delay) {
+      await page.waitForTimeout(2 * 1000);
+    }
+    await page.getByRole('button', { name }).click();
+  });
+};
+
+export const clickContinueNext = async (
+  test: SBLPlaywrightTest,
+  page: Page,
+) => {
+  await clickContinueHelper({
+    name: 'Continue to next step',
+    test,
+    page,
+    delay: true,
+  });
+};
+
+export const clickContinue = async (test: SBLPlaywrightTest, page: Page) => {
+  await clickContinueHelper({
+    name: 'Continue',
+    test,
+    page,
+    delay: false,
+  });
+};

--- a/e2e/utils/uploadFile.ts
+++ b/e2e/utils/uploadFile.ts
@@ -53,17 +53,11 @@ export async function uploadFile({
     const fileChooser = await fileChooserPromise;
     await fileChooser.setFiles(path.join(__dirname, filePath));
     await expect(pageUsed.getByText('File upload in progress')).toBeVisible();
-    await expect(pageUsed.getByText('File upload successful')).toBeVisible({
-      timeout: 10_000,
-    });
+    await expect(pageUsed.getByText('File upload successful')).toBeVisible();
     await expect(
       pageUsed.getByText('Validation checks in progress'),
-    ).toBeVisible({
-      timeout: 10_000,
-    });
-    await expect(pageUsed.getByText(resultMessage)).toBeVisible({
-      timeout: 60_000,
-    });
+    ).toBeVisible();
+    await expect(pageUsed.getByText(resultMessage)).toBeVisible();
   });
 }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,10 @@ import { PlaywrightTestConfig, devices } from '@playwright/test';
  */
 require('dotenv').config();
 
+const TIMEOUT_GLOBAL = 60 * 60 * 1000;
+const TIMEOUT_TEST = 5 * 60 * 1000;
+const TIMEOUT_EXPECT = 60 * 1000;
+
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -19,8 +23,17 @@ const config: PlaywrightTestConfig = {
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
+  /* Timeout for the entire test suite */
+  globalTimeout: TIMEOUT_GLOBAL,
+  /* Timeout for per test */
+  timeout: TIMEOUT_TEST,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
+  /* Expect specific settings */
+  expect: {
+    /* Timeout for expects */
+    timeout: TIMEOUT_EXPECT,
+  },
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     baseURL: 'http://localhost:8899/',


### PR DESCRIPTION
Adjusted timeouts to make e2e tests run consistently with up to 4 workers.

## Changes

- Added explicit timeouts to the playwright configuration
  - Test Suite Timeout of 1 Hour
  - Individual Test Timeout of 5 Minutes
  - Expect Timeout of 60 Seconds
- Removed individual expect timeouts from tests
- Removed test.slow calls
- Removed test.setTimeout calls
- Created functions for clicking the 'continue' and 'continue to next step' buttons
  - Allowed the continue to next function to explicitly wait before clicking the button
  - This was a large part of the fix and as such these functions should be used in the future
- Replaced all instances of clicking 'Continue' and 'Continue to next step' buttons with the new functions

## How to test this PR

1. Pull the branch
2. Restart the stack if necessary
3. From within the sbl-frontend directory run the following command: yarn playwright test --ui --workers 4
4. In the Playwright UI that appears run all of the tests together
5. Verify that all tests pass
6. Run them all again
7. Verify that they all still pass

## Screen shots
![Screenshot 2024-10-23 at 2 43 44 PM](https://github.com/user-attachments/assets/65518c5e-a483-4a3b-85d9-98973adad9ca)