### PR TITLE
[Institution profile] Page-level error for API issues

### DIFF
--- a/src/pages/Filing/ViewInstitutionProfile/index.tsx
+++ b/src/pages/Filing/ViewInstitutionProfile/index.tsx
@@ -1,13 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchInstitutionDetails } from 'api/requests';
 import useSblAuth from 'api/useSblAuth';
+import CommonLinks from 'components/CommonLinks';
 import CrumbTrail from 'components/CrumbTrail';
 import FormHeaderWrapper from 'components/FormHeaderWrapper';
 import FormWrapper from 'components/FormWrapper';
 import { Link } from 'components/Link';
 import { LoadingContent } from 'components/Loading';
+import { Alert } from 'design-system-react';
 import { useParams } from 'react-router-dom';
-import { Error500 } from '../../Error/Error500';
 import { AffiliateInformation } from './AffiliateInformation';
 import { FinancialInstitutionDetails } from './FinancialInstitutionDetails';
 import { IdentifyingInformation } from './IdentifyingInformation';
@@ -23,10 +24,25 @@ function InstitutionDetails(): JSX.Element | null {
   );
 
   if (isLoading) return <LoadingContent />;
-  if (isError)
-    return (
-      <Error500 error={{ message: 'Unable to fetch institution details.' }} />
-    );
+
+  const errorMessage = 'A problem occurred when trying to load your profile';
+
+  const content = isError ? (
+    <Alert status='error' message={errorMessage}>
+      Try again in a few minutes. If this issues persists,{' '}
+      <CommonLinks.EmailSupportStaff subject={`[Error] ${errorMessage}`} />.
+    </Alert>
+  ) : (
+    <>
+      <FinancialInstitutionDetails data={data} />
+      <IdentifyingInformation data={data} />
+      <AffiliateInformation data={data} />
+      {/* TODO: include history of changes after MVP
+          https://github.com/cfpb/sbl-project/issues/39
+        <ChangeHistory /> 
+        */}
+    </>
+  );
 
   return (
     <main id='main'>
@@ -39,13 +55,7 @@ function InstitutionDetails(): JSX.Element | null {
         <FormHeaderWrapper>
           <PageIntro />
         </FormHeaderWrapper>
-        <FinancialInstitutionDetails data={data} />
-        <IdentifyingInformation data={data} />
-        <AffiliateInformation data={data} />
-        {/* TODO: include history of changes after MVP
-          https://github.com/cfpb/sbl-project/issues/39
-        <ChangeHistory /> 
-        */}
+        {content}
       </FormWrapper>
     </main>
   );


### PR DESCRIPTION
Closes #1030 

## Changes

- Render page-level error alert for API errors, as opposed to rendering a separate `500` page

## How to test this PR

1. Block API requests from the following source in Chrome dev tools:
    1. `localhost:8881/v1/institutions/123456789TESTBANK123`
2. Visit http://localhost:8899/institution/123456789TESTBANK123
3. Observe that things reflect the screenshot below.

## Screenshots

<img width="1195" alt="Screenshot 2024-11-07 at 3 05 43 PM" src="https://github.com/user-attachments/assets/0ece11ba-292d-433b-91cf-cc21f702cf3d">
